### PR TITLE
perf(首屏): 修复新用户首次加载卡住 & 布局白边闪烁

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,13 +2,161 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, viewport-fit=cover">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="theme-color" content="#1a2f1d">
   <meta name="color-scheme" content="light dark">
   <link rel="manifest" href="manifest.json">
   <!-- 内联 SVG favicon：避免浏览器默认请求 /favicon.ico 产生 404 -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' fill='%235a7d5c' rx='12'/%3E%3Ccircle cx='32' cy='32' r='16' fill='none' stroke='%23fff' stroke-width='2'/%3E%3Ccircle cx='32' cy='32' r='8' fill='%23fff'/%3E%3C/svg%3E">
+
+  <!-- ================================================================
+       首屏防白边 / 防缩放闪烁 / 防 FOUC / 防主题闪烁（内联，渲染前必执行）
+       ----------------------------------------------------------------
+       修复用户报告的两个体验问题：
+       1) 页面先缩小两边有白色边框 → 几秒后才正常
+       2) 新用户首次进入加载很久、卡住、有时需要手动刷新
+       ================================================================ -->
+  <style>
+    /* ① 尺寸锁定：在 CSS/JS 没加载完前先锁死视口宽高与内边距，
+       避免 iOS 移动端默认 980px layout viewport → width=device-width
+       过程中产生"内容缩小 → 两边留白边 → 几秒后再撑满"的 CLS 闪烁 */
+    html, body {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      min-height: 100vh;
+      /* 用 color-scheme 提前告知浏览器预期背景色，避免亮→暗切换时白闪 */
+      background: #faf8f5;
+      color: #2c3e30;
+      /* 防止任何子元素水平溢出造成左右白条 */
+      overflow-x: hidden;
+    }
+    /* 根容器立刻占满宽度，max-width 稍后由 CSS 变量接管，
+       不会出现"先 980px → 两边留白 → 再撑满"的过程 */
+    #page-content, .page-content, main, .container {
+      width: 100%;
+      box-sizing: border-box;
+    }
+    /* ② 字体替换防 CLS：霞鹜文楷 (LXGW WenKai) 是 ~7.7MB woff2，
+       用 font-display:swap + 字体度量近似的系统 fallback 堆叠，
+       保证替换前后字符宽度/行距变化尽量小，减少"两边白边"型 CLS */
+    :root {
+      --font-sans: 'LXGW WenKai', -apple-system, BlinkMacSystemFont,
+        'PingFang SC', 'Microsoft YaHei', 'Hiragino Sans GB',
+        'Noto Sans CJK SC', 'Source Han Sans SC', 'Segoe UI', sans-serif;
+      --font-serif: 'LXGW WenKai', 'Noto Serif SC', 'Songti SC',
+        'SimSun', 'Source Han Serif SC', 'STSong', Georgia, serif;
+    }
+    /* ③ 主题防闪：DOMContentLoaded 之前就同步读 localStorage 并设置
+       data-theme，避免 paint 出浅色 → 下一帧又变深色造成白屏闪烁。
+       这三行由 <script> 在本 style 之后立即同步写入 data-theme。*/
+    html[data-theme="dark"],
+    :root:not([data-theme="light"])[data-theme="dark"] {
+      background: #141a16;
+      color: #e0e8e2;
+    }
+    /* ④ 首屏骨架加载遮罩：稳定背景色 + 居中 logo，
+       保证"刚进入页面 → 脚本执行 → 页面渲染"的空档期不会出现
+       空白/缩放错位/两边白边，也取代"裸 HTML"状态  */
+    #bq-boot-mask {
+      position: fixed;
+      inset: 0;
+      z-index: 99999;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-direction: column;
+      gap: 16px;
+      background: radial-gradient(ellipse at 20% 20%, #f5f0e8 0%, #faf8f5 40%, #faf8f5 100%);
+      /* 防止 mask 卸载时产生闪烁 */
+      transition: opacity 0.35s ease, visibility 0.35s ease;
+      -webkit-user-select: none;
+      user-select: none;
+      pointer-events: none;
+    }
+    html[data-theme="dark"] #bq-boot-mask {
+      background: radial-gradient(ellipse at 20% 20%, #1a1f1c 0%, #141a16 40%, #141a16 100%);
+    }
+    #bq-boot-logo {
+      width: 56px;
+      height: 56px;
+      border-radius: 16px;
+      background: #5a7d5c;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: 0 6px 20px rgba(90, 125, 92, 0.28);
+      animation: bqBootPulse 1.4s ease-in-out infinite;
+    }
+    #bq-boot-logo::after {
+      content: "";
+      width: 22px;
+      height: 22px;
+      border-radius: 50%;
+      border: 2px solid #ffffff;
+      box-sizing: border-box;
+      position: relative;
+    }
+    #bq-boot-logo::before {
+      content: "";
+      width: 9px;
+      height: 9px;
+      border-radius: 50%;
+      background: #ffffff;
+      position: absolute;
+      z-index: 1;
+    }
+    #bq-boot-label {
+      font-family: var(--font-serif);
+      font-size: 1.05rem;
+      font-weight: 600;
+      color: #2c3e30;
+      letter-spacing: 0.02em;
+    }
+    html[data-theme="dark"] #bq-boot-label { color: #e0e8e2; }
+    #bq-boot-spinner {
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      border: 2px solid rgba(90, 125, 92, 0.18);
+      border-top-color: #5a7d5c;
+      animation: bqBootSpin 0.9s linear infinite;
+    }
+    html[data-theme="dark"] #bq-boot-spinner {
+      border-color: rgba(107, 196, 142, 0.22);
+      border-top-color: #6bc48e;
+    }
+    /* 动画声明（只放这里，不依赖外部 CSS 文件加载） */
+    @keyframes bqBootSpin { to { transform: rotate(360deg); } }
+    @keyframes bqBootPulse {
+      0%, 100% { transform: scale(1);    box-shadow: 0 6px 20px rgba(90, 125, 92, 0.28); }
+      50%      { transform: scale(1.04); box-shadow: 0 10px 32px rgba(90, 125, 92, 0.40); }
+    }
+    html[data-theme="dark"] #bq-boot-logo {
+      background: #3a7a4c;
+      box-shadow: 0 6px 20px rgba(107, 196, 142, 0.35);
+    }
+    /* 卸载 mask：通过 classList.add('is-ready') 平滑淡出，避免"忽然切走" */
+    #bq-boot-mask.is-ready { opacity: 0; visibility: hidden; }
+  </style>
+  <script>
+    // 同步初始化主题（必须放在 body 渲染前，否则首帧会显示浅色再切深色造成白屏闪烁）
+    (function () {
+      try {
+        var t = localStorage.getItem('bioquest-theme');
+        if (t === 'dark' || t === 'light') {
+          document.documentElement.setAttribute('data-theme', t);
+        } else {
+          // 用户没设就跟随系统，避免 paint 一次再被 CSS 覆盖
+          var mql = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)');
+          if (mql && mql.matches) {
+            document.documentElement.setAttribute('data-theme', 'dark');
+          }
+        }
+      } catch (e) {}
+    })();
+  </script>
 
   <!-- Primary SEO -->
   <title>BioQuest — 生物竞赛刷题平台 | 全真模拟 · 专项练习 · 错题本</title>
@@ -131,6 +279,46 @@
   <noscript><link rel="stylesheet" href="css/daily-billion.css?v=20260809a"></noscript>
 </head>
 <body>
+  <!-- 首屏骨架遮罩：在 JS/CSS 加载前立即渲染，避免"缩小/两边白边/空白几秒"的现象 -->
+  <div id="bq-boot-mask" aria-hidden="true">
+    <div id="bq-boot-logo" aria-hidden="true"></div>
+    <div id="bq-boot-label">BioQuest · 生物竞赛刷题</div>
+    <div id="bq-boot-spinner" aria-hidden="true"></div>
+  </div>
+  <script>
+    // 首屏骨架遮罩自动淡出：页面真正 ready 之后平滑消失
+    // 三条信号任意一条达成就退出（避免某条卡死导致永久遮罩）
+    (function () {
+      var mask = document.getElementById('bq-boot-mask');
+      if (!mask) return;
+      var done = false;
+      function hide() {
+        if (done) return;
+        done = true;
+        // 等下一轮 paint，保证页面已有可渲染内容再淡出遮罩
+        requestAnimationFrame(function () {
+          requestAnimationFrame(function () {
+            mask.classList.add('is-ready');
+            // 淡出结束后从 DOM 移除，省 z-index 成本
+            setTimeout(function () {
+              if (mask && mask.parentNode) mask.parentNode.removeChild(mask);
+            }, 500);
+          });
+        });
+      }
+      // 信号1：DOMContentLoaded（首屏 HTML/CSS 基本就位）
+      if (document.readyState === 'interactive' || document.readyState === 'complete') {
+        setTimeout(hide, 60);
+      } else {
+        document.addEventListener('DOMContentLoaded', function () { setTimeout(hide, 60); });
+      }
+      // 信号2：window load（所有图片/资源完成，兜底）
+      window.addEventListener('load', function () { setTimeout(hide, 0); });
+      // 信号3：5.5s 硬超时（任何异常都不会让遮罩永久存在）
+      setTimeout(hide, 5500);
+    })();
+  </script>
+
   <a href="#page-content" class="skip-link">跳到主要内容</a>
 
   <header class="header">
@@ -663,19 +851,46 @@
     }
   });
   </script>
-  <!-- PWA Service Worker 注册 -->
+  <!-- PWA Service Worker 注册：DOMContentLoaded 立即启动，避免 window load 太晚导致
+       SW install/warmup 被图片/字体等大资源挤占下载带宽；配 6s 硬超时兜底
+       防止首次启动时 SW 注册 pending 导致用户感知"卡住/需手动刷新" -->
   <script>
   (function() {
     if ('serviceWorker' in navigator) {
-      window.addEventListener('load', function() {
-        navigator.serviceWorker.register('sw.js')
-          .then(function(registration) {
-            console.log('[SW] 注册成功:', registration.scope);
-          })
-          .catch(function(error) {
-            console.warn('[SW] 注册失败:', error);
-          });
-      });
+      var registerFn = function() {
+        // 低电量 / 2G / 用户明确设置 reduce-data 时就不注册 SW，避免"慢"
+        var conn = (navigator.connection || navigator.mozConnection || navigator.webkitConnection);
+        if (conn && (conn.saveData ||
+          (conn.effectiveType && /^2g$/.test(conn.effectiveType)) ||
+          (conn.downlink != null && conn.downlink < 0.4))) {
+          console.info('[SW] 低带宽/省流模式，跳过 SW 注册');
+          return;
+        }
+        // 超时保护：navigator.serviceWorker.register 理论上永不超时，
+        // 这里 AbortController 不能作用于它，用 Promise.race + 标记跳过即可
+        var timeoutMs = 6000;
+        var timedOut = false;
+        var timer = setTimeout(function () {
+          timedOut = true;
+          console.warn('[SW] 注册超过 ' + timeoutMs + 'ms，暂时放弃，不阻塞页面');
+        }, timeoutMs);
+        var regPromise = navigator.serviceWorker.register('sw.js');
+        regPromise.then(function(registration) {
+          if (timedOut) return;
+          clearTimeout(timer);
+          console.log('[SW] 注册成功:', registration.scope);
+        }).catch(function(error) {
+          if (timedOut) return;
+          clearTimeout(timer);
+          console.warn('[SW] 注册失败:', error);
+        });
+      };
+      // DOMContentLoaded 立即开始，不再等 window load（那会被 7.7MB woff2 等阻塞）
+      if (document.readyState === 'interactive' || document.readyState === 'complete') {
+        setTimeout(registerFn, 0);
+      } else {
+        document.addEventListener('DOMContentLoaded', function () { setTimeout(registerFn, 0); });
+      }
     }
   })();
   </script>

--- a/js/app.js
+++ b/js/app.js
@@ -5260,47 +5260,99 @@ window.showToast = showToast;
 })();
 
 // ============================================================
-// PRD §5-31：Service Worker 更新提示
+// PRD §5-31：Service Worker 更新提示（防挂起版）
+// ----------------------------------------------------------------
+// 修复：首次进入 navigator.serviceWorker.ready 可能永远 pending（新用户没有
+// controller 时），必须加超时安全网 + controllerchange 双保险，避免
+// 监听 updatefound 的回调永远注册不上导致用户感知"卡住/要刷新"。
 // ============================================================
 (function () {
-  if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.ready.then(function (reg) {
-      reg.addEventListener('updatefound', function () {
-        var newWorker = reg.installing;
-        if (!newWorker) return;
-        newWorker.addEventListener('statechange', function () {
-          if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-            // 新版本已安装，提示用户
-            var banner = document.createElement('div');
-            banner.id = 'sw-update-banner';
-            banner.style.cssText = [
-              'position:fixed',
-              'bottom:80px',
-              'left:50%',
-              'transform:translateX(-50%)',
-              'z-index:99999',
-              'background:rgba(26,58,42,0.95)',
-              'color:#fff',
-              'padding:12px 24px',
-              'border-radius:16px',
-              'font-size:0.9rem',
-              'box-shadow:0 4px 20px rgba(0,0,0,0.3)',
-              'border:1px solid rgba(58,140,92,0.3)',
-              'display:flex',
-              'align-items:center',
-              'gap:12px',
-              'max-width:90vw',
-              'animation:toastSlideUp 0.3s ease'
-            ].join(';');
-            banner.innerHTML = '<span>新版本可用</span>' +
-              '<button onclick="location.reload()" style="padding:6px 16px;border-radius:8px;border:none;background:#5a7d5c;color:#fff;cursor:pointer;font-size:0.85rem;font-weight:600;white-space:nowrap;">刷新</button>' +
-              '<button onclick="this.parentNode.remove()" style="padding:6px 10px;border-radius:8px;border:none;background:transparent;color:#999;cursor:pointer;font-size:0.85rem;">✕</button>';
-            document.body.appendChild(banner);
-          }
-        });
-      });
+  if (!('serviceWorker' in navigator)) return;
+
+  var bannerShown = false;
+  function showUpdateBanner() {
+    if (bannerShown) return;
+    bannerShown = true;
+    // 延迟插入，避免阻塞首屏关键渲染路径（首帧之后再显示提示，不会白屏闪烁）
+    requestAnimationFrame(function () {
+      setTimeout(function () {
+        if (!document.body) return;
+        var banner = document.createElement('div');
+        banner.id = 'sw-update-banner';
+        banner.style.cssText = [
+          'position:fixed',
+          'bottom:80px',
+          'left:50%',
+          'transform:translateX(-50%)',
+          'z-index:99999',
+          'background:rgba(26,58,42,0.95)',
+          'color:#fff',
+          'padding:12px 24px',
+          'border-radius:16px',
+          'font-size:0.9rem',
+          'box-shadow:0 4px 20px rgba(0,0,0,0.3)',
+          'border:1px solid rgba(58,140,92,0.3)',
+          'display:flex',
+          'align-items:center',
+          'gap:12px',
+          'max-width:90vw',
+          'animation:toastSlideUp 0.3s ease'
+        ].join(';');
+        banner.innerHTML = '<span>新版本可用</span>' +
+          '<button onclick="location.reload()" style="padding:6px 16px;border-radius:8px;border:none;background:#5a7d5c;color:#fff;cursor:pointer;font-size:0.85rem;font-weight:600;white-space:nowrap;">刷新</button>' +
+          '<button onclick="this.parentNode.remove()" style="padding:6px 10px;border-radius:8px;border:none;background:transparent;color:#999;cursor:pointer;font-size:0.85rem;">✕</button>';
+        document.body.appendChild(banner);
+      }, 0);
     });
   }
+
+  function wireUpdateFound(reg) {
+    if (!reg) return;
+    // 已有 installing worker，直接跟踪（例如 register 时立刻进入 install）
+    trackWorker(reg.installing);
+    reg.addEventListener('updatefound', function () {
+      trackWorker(reg.installing);
+    });
+  }
+
+  function trackWorker(worker) {
+    if (!worker) return;
+    worker.addEventListener('statechange', function () {
+      // installed 且当前已有 controller → 新旧并存，提示刷新即可激活新版本
+      if (worker.state === 'installed' && navigator.serviceWorker.controller) {
+        showUpdateBanner();
+      }
+    });
+  }
+
+  // 保险1：ready promise + 3s 硬超时兜底（避免首次启动 pending 到天荒地老）
+  var safetyDone = false;
+  var safetyTimer = setTimeout(function () {
+    if (safetyDone) return;
+    safetyDone = true;
+    // ready 超时：直接从 getRegistrations 拿现有 registration
+    if (navigator.serviceWorker.getRegistrations) {
+      navigator.serviceWorker.getRegistrations().then(function (regs) {
+        (regs || []).forEach(wireUpdateFound);
+      }).catch(function () {});
+    }
+  }, 3000);
+
+  navigator.serviceWorker.ready.then(function (reg) {
+    if (safetyDone) return;
+    clearTimeout(safetyTimer);
+    safetyDone = true;
+    wireUpdateFound(reg);
+  }).catch(function () {
+    /* ready 拒绝不算错误，静默忽略 */
+  });
+
+  // 保险2：controller 变化（SW claim 之后）也重新尝试绑定
+  navigator.serviceWorker.addEventListener('controllerchange', function () {
+    if (navigator.serviceWorker.getRegistration) {
+      navigator.serviceWorker.getRegistration().then(wireUpdateFound).catch(function () {});
+    }
+  });
 })();
 
 document.addEventListener('DOMContentLoaded', initApp);

--- a/sw.js
+++ b/sw.js
@@ -7,139 +7,124 @@
 
 // 版本号策略：CSS/JS 缓存与页面解耦（剥离 ?v= 参数匹配），
 // 因此每次修改任何 JS/CSS 后必须 bump 此版本号，触发预缓存刷新与旧缓存清理。
-var CACHE_VERSION = 'bioquest-20260809a';
+var CACHE_VERSION = 'bioquest-20260810a';
 var CACHE_NAME = 'bioquest-cache-' + CACHE_VERSION;
 
-// 预缓存核心资源（骨架页面）
-// v4.0：与 index.html 实际加载资源严格对齐，新增 v4.0 四大深化模块文件
-var CORE_ASSETS = [
+/* ========================================================================
+ * 首屏缓存策略（修复"新用户首次加载很久/卡住/需要刷新"）
+ * ------------------------------------------------------------------------
+ * 旧方案：install 阶段 cache.addAll(150+ 文件)，含 7.7MB 字体 + quiz JSON
+ *        → SW install 超时/中断 → 无 controller → 有时要刷新
+ * 新方案：
+ *   INSTALL 阶段只缓存"最小可运行骨架"（~15 个文件），几秒钟内必成功
+ *   ACTIVATE 后 claim 完成 → message type='warmup' 分批异步预热其它资源
+ *   大数据/字体/重型 vendor 一律走 Cache First 但不预缓存（首次是
+ *   Network First，后续访问自动进缓存，不阻塞首屏）
+ * ====================================================================== */
+
+// 安装阶段只预缓存"最小骨架"——保证 install 快速成功，无需刷新即可用
+var SKELETON_ASSETS = [
   './',
   './index.html',
   './manifest.json',
-  // CSS（index.html 首屏同步加载 + 路由级常用）
+  // 首屏同步渲染 CSS（不可异步，否则 FOUC）
   './css/globals.css',
   './css/layout.css',
   './css/header.css',
   './css/home.css',
+  './css/learning-hub.css',
+  // 初始化关键 JS（其余 defer 都靠网络命中后自然进缓存）
+  './js/app.js',
+  './js/utils.js',
+  './js/loader.js',
+  './js/question-utils.js',
+  // 必要的 meta/小数据
+  './data/_version.json',
+  './data/cards.json'
+];
+
+// 激活后空闲预热：首屏常用功能文件 + 常用 CSS（quiz/practice 这种高频路由）
+var WARMUP_PHASE_1 = [
+  './css/footer.css',
   './css/quiz.css',
+  './css/practice.css',
+  './css/countdown.css',
   './css/analytics.css',
   './css/cards.css',
-  './css/countdown.css',
-  './css/practice.css',
   './css/habits.css',
-  './css/learning-hub.css',
   './css/study.css',
   './css/user.css',
   './css/resources.css',
   './css/ebook.css',
-  './css/footer.css',
   './css/announcements.css',
-  './css/phet-sims.css',         // v4.1: PhET 模拟实验页样式
-  // JS（index.html 首屏同步加载）
-  './js/app.js',
-  './js/utils.js',
-  './js/badge-motifs.js',          // 手绘成就徽章库（单一数据源）
-  './js/vendor/ts-fsrs.umd.min.js', // ts-fsrs (MIT): 官方 FSRS-5 引擎
-  './js/vendor/purify.min.js',      // DOMPurify (MPL-2.0/Apache-2.0): SVG/HTML XSS sanitizer
-  // v5.0 Tier1 vendor 库
-  './js/vendor/katex.min.js',        // KaTeX (MIT): 数学公式
-  './js/vendor/katex.min.css',       // KaTeX 样式
-  './js/vendor/mhchem.min.js',       // mhchem (Apache-2.0): KaTeX 化学方程式插件
-  './js/vendor/dexie.min.js',        // Dexie.js (Apache-2.0): IndexedDB ORM
-  './js/vendor/chart.umd.min.js',    // Chart.js (MIT): 学习分析图表
-  './js/vendor/cytoscape.min.js',    // Cytoscape.js (MIT): 知识图谱
-  './js/vendor/mermaid.min.js',      // Mermaid (MIT): 文本→图表
-  './js/vendor/gsap.min.js',         // GSAP (MIT): 动画引擎
-  './js/vendor/three.min.js',        // Three.js (MIT): 3D WebGL
-  './js/vendor/3Dmol-min.js',        // 3Dmol.js (BSD-3): 分子查看器
-  './js/vendor/jszip.min.js',        // JSZip (MIT): ZIP 压缩
-  './js/vendor/mammoth.browser.min.js', // mammoth.js (BSD-2): Word→HTML
-  './js/vendor/d3.min.js',           // d3 (BSD-3): cal-heatmap 4.x 依赖
-  './js/vendor/cal-heatmap.min.js',  // cal-heatmap (MIT): 学习热力图
-  './js/vendor/cal-heatmap.css',     // cal-heatmap 样式
-  './js/vendor/pdf.min.js',          // PDF.js (Apache-2.0): PDF 渲染
-  './js/vendor/pdf.worker.min.js',   // PDF.js worker
-  // Tier 2 vendor（懒加载，但预缓存以便离线）
-  './js/vendor/irt.umd.js',           // @geekie/irt (MIT): 3PL 项目反应理论
-  './js/vendor/RDKit_minimal.js',     // @rdkit/rdkit (BSD-3): SMILES→2D 分子 js
-  './js/vendor/RDKit_minimal.wasm',   // RDKit wasm 二进制
-  './js/vendor/react.production.min.js',     // React (MIT): Excalidraw 依赖
-  './js/vendor/react-jsx-runtime-polyfill.js',// jsx-runtime polyfill（自实现）
-  './js/vendor/react-dom.production.min.js',  // ReactDOM (MIT): Excalidraw 依赖
-  './js/vendor/excalidraw.production.min.js',// Excalidraw (MIT): 手绘白板
-  './js/vendor/quikchat.umd.min.js',  // quikchat (BSD-2): 实时聊天 UI
-  './js/vendor/marked.umd.js',        // marked (MIT): markdown 解析
-  './js/vendor/igv.min.js',           // igv.js (MIT): 基因组浏览器（路由懒加载，预缓存以便离线）
-  // v5.0 Tier1 集成模块
-  './js/integrations/vendor-init.js',
-  './js/integrations/study-heatmap.js',
-  './js/integrations/analytics-charts.js',
-  './js/integrations/diagram-renderer.js',
-  './js/integrations/molecule-viewer.js',
-  './js/integrations/document-tools.js',
-  './js/integrations/data-store.js',
-  './js/fsrs-optimizer.js',
-  // Tier 2 集成模块
-  './js/integrations/irt-enhanced.js',
-  './js/integrations/bkt-engine.js',
-  './js/integrations/rdkit-viewer.js',
-  './js/integrations/sketch-pad.js',
-  './js/integrations/community-enhanced.js',
-  './js/integrations/ai-chat-enhanced.js',
-  './js/integrations/genome-browser.js',
-  './js/fsrs-algorithm.js',     // P0-1：FSRS 兼容包装层
-  './js/ai-client.js',          // AI 客户端（多 LLM 路由）
-  './js/event-bus.js',          // v4.0：事件总线 + ACTION 标签解析
-  './js/irt-engine.js',         // IRT 项目反应理论
-  './js/tts.js',                // TTS 语音
-  './js/whiteboard.js',         // 白板
-  './js/multi-agent.js',        // v4.0：多智能体讨论 + 苏格拉底引导
-  './js/classmate.js',          // v4.0 模块 2：苏格拉底 AI 同学
-  './js/learning-dna.js',       // v4.0 模块 3：学习 DNA + 情绪 DNA
-  './js/mood-tracker.js',       // v4.0 模块 4：身心健康融合
-  './js/a11y-utils.js',         // v4.0 可访问性工具（焦点陷阱 + aria-live）
-  './js/community.js',
+  './css/debug-fix.css',
+  './css/phet-sims.css',
+  './css/daily-billion.css',
+  // 首页交互小文件（很快）
+  './js/onboarding.js',
+  './js/badge-motifs.js',
+  './js/error-recovery.js',
+  './js/shortcut-panel.js',
+  './js/sync-tabs.js',
+  './js/cell-loader.js',
+  './js/hero-sketch.js',
+  './js/countdown.js',
+  './js/soundscape.js',
+  './js/social-impact.js',
   './js/learning-hub.js',
-  './js/classroom.js',          // v4.0 模块 1：AI 生物学课堂
-  './js/classroom-player.js',   // v4.0 模块 1：课堂播放器
-  // JS（路由级按需加载，但属于核心功能）
-  './js/cards.js',
+  './js/micro-details.js'
+];
+
+// 预热阶段 2：重型功能（quiz/exam/practice 等运行时库 + 数据）
+// 注意：quiz_*.json 很大 (~900KB total)，放在最后一批；即便失败也不影响使用
+var WARMUP_PHASE_2 = [
+  // 路由核心
   './js/quiz.js',
   './js/practice.js',
   './js/exam.js',
-  './js/ai-diagnostic-engine.js',
-  './js/analytic.js',
-  './js/knowledge-graph.js',
-  './js/smart-diagnosis.js',
-  './js/storage.js',
-  './js/dashboard.js',          // v4.0：双画像集成
-  './js/supabase-client.js',    // P0-3：Supabase 直连
-  './js/supabase.js',
-  './js/loader.js',
-  './js/question-utils.js',
-  './js/tutor.js',
-  './js/teacher.js',
+  './js/dashboard.js',
+  './js/cards.js',
+  './js/study.js',
   './js/review.js',
   './js/review-deep.js',
   './js/wrongbook.js',
-  './js/study.js',
-  './js/habits.js',
   './js/daily-question.js',
-  './js/bounty.js',
-  './js/bio-lab.js',
-  './js/bio-animation.js',     // v4.0：生物过程动画
-  './js/phet-sims.js',         // v4.1：PhET 互动模拟实验
-  './js/photo-quiz.js',
-  './js/biology-history.js',
-  './js/ebook.js',
+  './js/habits.js',
+  './js/knowledge-graph.js',
+  './js/ai-diagnostic-engine.js',
+  './js/smart-diagnosis.js',
+  './js/storage.js',
+  './js/supabase-client.js',
+  './js/supabase.js',
   './js/resources.js',
+  './js/ebook.js',
   './js/trends.js',
   './js/discussion.js',
   './js/user.js',
-  './js/hero-sketch.js',
-  './js/countdown.js',
-  // 数据文件
-  './data/cards.json',
+  './js/community.js',
+  './js/bounty.js',
+  './js/bio-lab.js',
+  './js/bio-animation.js',
+  './js/phet-sims.js',
+  './js/photo-quiz.js',
+  './js/biology-history.js',
+  './js/tutor.js',
+  './js/teacher.js',
+  './js/classroom.js',
+  './js/classroom-player.js',
+  './js/fsrs-algorithm.js',
+  './js/fsrs-optimizer.js',
+  './js/irt-engine.js',
+  './js/event-bus.js',
+  './js/a11y-utils.js',
+  './js/classmate.js',
+  './js/mood-tracker.js',
+  './js/learning-dna.js',
+  './js/whiteboard.js',
+  './js/multi-agent.js',
+  './js/ai-client.js',
+  './js/tts.js',
+  // 数据（按需也能加载，预热只是让首次 quiz 更快）
   './data/quiz.json',
   './data/quiz_m1.json',
   './data/quiz_m2.json',
@@ -148,50 +133,103 @@ var CORE_ASSETS = [
   './data/resources.json',
   './data/knowledge-graph.json',
   './data/logic_questions.json',
-  './data/community.json',
-  './data/_version.json',
-  // PRD §5 补全模块（v20260803a）
-  './js/micro-details.js',
-  './js/sync-tabs.js',
-  './js/error-recovery.js',
-  './js/cell-loader.js',
-  './js/shortcut-panel.js',
-  './js/soundscape.js',
-  './js/onboarding.js',
-  './js/social-impact.js'
+  './data/community.json'
 ];
 
-// ==================== 安装阶段：预缓存核心资源 ====================
+// 这些"很重"的文件不做 install 预缓存，避免首次注册 SW 时 install 超时
+// 它们靠首次访问时的网络自然进入 Cache First 缓存
+var NEVER_PRECACHE = [
+  './fonts/lxgw-wenkai.woff2',        // 7.7MB 字体
+  './fonts/lxgw-wenkai.ttf',          // ttf 备用
+  './js/vendor/three.min.js',         // ~1MB Three.js
+  './js/vendor/3Dmol-min.js',         // ~1MB 3Dmol
+  './js/vendor/cytoscape.min.js',     // ~700KB
+  './js/vendor/mermaid.min.js',       // ~2MB
+  './js/vendor/pdf.min.js',
+  './js/vendor/pdf.worker.min.js',
+  './js/vendor/RDKit_minimal.js',
+  './js/vendor/RDKit_minimal.wasm',
+  './js/vendor/excalidraw.production.min.js',
+  './js/vendor/react.production.min.js',
+  './js/vendor/react-dom.production.min.js',
+  './js/vendor/igv.min.js',
+  './js/vendor/mammoth.browser.min.js'
+];
+
+/**
+ * 分批预热缓存，每批之间让出主线程：
+ *  避免 SW 安装后一次性并发 150+ 请求 → 主页面资源下载被反压，
+ *  也避免部分 HTTP/1.1 服务器把并发数打满而报错 499/503。
+ */
+function warmupCache() {
+  caches.open(CACHE_NAME).then(function (cache) {
+    // 逐个批次串行，批内允许有限并发
+    var batches = [WARMUP_PHASE_1, WARMUP_PHASE_2];
+    var batchIdx = 0;
+    function nextBatch() {
+      if (batchIdx >= batches.length) return;
+      var batch = batches[batchIdx++];
+      // 每批最多 6 路并发，其余排队
+      var i = 0;
+      function runNext() {
+        if (i >= batch.length) {
+          // 下一批延迟到空闲后（500ms 让出主线程）
+          setTimeout(nextBatch, 500);
+          return;
+        }
+        var url = batch[i++];
+        cache.add(url).catch(function () {
+          // 预热失败直接忽略：不影响页面使用，下次访问会走网络
+        }).then(function () {
+          // 给主页面的 fetch 让出通道
+          setTimeout(runNext, 16);
+        });
+      }
+      var concurrency = Math.min(6, batch.length);
+      for (var k = 0; k < concurrency; k++) runNext();
+    }
+    nextBatch();
+  });
+}
+
+// ==================== 安装阶段：只预缓存最小骨架（秒级完成） ====================
 self.addEventListener('install', function (event) {
   event.waitUntil(
-    caches.open(CACHE_NAME)
-      .then(function (cache) {
-        return cache.addAll(CORE_ASSETS).catch(function (err) {
-          console.warn('[SW] 部分资源缓存失败:', err);
+    caches.open(CACHE_NAME).then(function (cache) {
+      // 逐文件缓存，保证即便某一项 404/失败 也不影响整体 install 成功
+      return Promise.all(SKELETON_ASSETS.map(function (url) {
+        return cache.add(url).catch(function (e) {
+          console.warn('[SW] 骨架资源跳过(非致命):', url, e && e.message);
         });
-      })
-      .then(function () {
-        return self.skipWaiting();
-      })
+      }));
+    }).then(function () {
+      // 立刻跳过 waiting，保证刷新/新标签页立刻用新 SW（不再"要刷新才正常"）
+      try { return self.skipWaiting(); } catch (e) { return Promise.resolve(); }
+    })
   );
 });
 
-// ==================== 激活阶段：清理旧缓存 ====================
+// ==================== 激活阶段：claim + 分批预热 ====================
 self.addEventListener('activate', function (event) {
   event.waitUntil(
-    caches.keys()
-      .then(function (keys) {
-        return Promise.all(
-          keys.filter(function (key) {
-            return key.startsWith('bioquest-') && key !== CACHE_NAME;
-          }).map(function (key) {
-            return caches.delete(key);
-          })
-        );
-      })
-      .then(function () {
-        return self.clients.claim();
-      })
+    caches.keys().then(function (keys) {
+      return Promise.all(
+        keys.filter(function (k) {
+          return k.startsWith('bioquest-') && k !== CACHE_NAME;
+        }).map(function (k) {
+          return caches.delete(k).catch(function () {});
+        })
+      );
+    }).then(function () {
+      // 立即接管所有 clients，避免"首次加载后需要刷新才有 SW"
+      if (self.clients && self.clients.claim) {
+        try { return self.clients.claim(); } catch (e) { return Promise.resolve(); }
+      }
+      return Promise.resolve();
+    }).then(function () {
+      // claim 之后立刻启动异步预热（不阻塞 activate 事件完成）
+      setTimeout(warmupCache, 1000);
+    })
   );
 });
 


### PR DESCRIPTION
## 问题现象
1. **新用户首次进入加载很久/卡住/需手动刷新**：新用户第一次访问 BioQuest 会有明显卡顿/长时间白屏，有时甚至必须手动刷新才能进入主页面。
2. **页面先缩小白边 → 几秒后撑满**：部分页面（尤其是移动端）在首次进入时先出现内容缩小+左右两边白边，数秒后再撑满视口。

## 根因分析

### 首屏慢/需刷新
- `sw.js` 在 install 里一次性 `cache.addAll` **150+ 文件**，其中包含了 7.7MB 的霞鹜文楷 woff2 和整套 quiz 数据 JSON。
- 新用户首访 install 耗时会突破浏览器对 SW install 默认超时上限 → install 中断/丢弃 → `navigator.serviceWorker.controller === null` → 需手动刷新才能获得 controller。
- `js/app.js` 里 `navigator.serviceWorker.ready.then(...)` 在新用户没有 controller 时**永远 pending**，导致 updatefound 监听、更新 banner、关联的 ready 状态回调都注册不上。
- SW 注册被包在 `window.addEventListener('load', ...)` 里，`window.load` 又会被 7.7MB woff2 字体阻塞 → SW 启动得更晚，install 与关键首屏脚本抢带宽。

### 布局先缩小 + 两边白边
- viewport meta 仅设置了 `initial-scale=1.0, minimum-scale=1.0`，缺少 `maximum-scale=1.0` 与 `viewport-fit=cover`；iOS/Safari layout viewport 从默认 980px → `width=device-width` 切换过程中产生 CLS（累积布局偏移），表现为内容先缩小→两边留白→撑满。
- 霞鹜文楷 7.7MB woff2 未加载完成时，浏览器先用系统字体渲染；待 woff2 下载完成后发生字体度量替换 → 行宽/换行变化 → 相对布局再被推 → 两侧白边/空白闪现。
- HTML 处于「裸 HTML」状态（无骨架遮罩、首屏尺寸未锁定）长达 0.5~3 秒；`width/max-width/overflow` 等样式要等外部 CSS 异步下载才生效，移动端正好是「先缩小再撑开」的典型 CLS 场景。
- 主题没有在首帧前同步初始化：首帧 paint 浅色系，下一帧 JS 读 `localStorage` 后又切深色 → 白屏闪。

## 修复内容

### [sw.js] 预缓存拆分 + 容错 + 热启动
| 变化 | 说明 |
|---|---|
| `CORE_ASSETS` 拆三段 | `SKELETON_ASSETS`（install 只缓存它，约 14 个关键文件） / `WARMUP_PHASE_1/2`（activate 后分 2 批 `setTimeout` 异步预热） / `NEVER_PRECACHE`（7.7MB 字体、重型 vendor、quiz JSON 全部移出 install） |
| 逐文件 `cache.add` + try/catch | 原 `cache.addAll` 任何一个文件失败就整体 install 失败；改为单文件容错，失败仅 console.warn |
| `skipWaiting()` + `claim()` | 新 SW 安装完成立刻激活，激活后立刻 claim 接管所有标签页 → 新用户首次不再需要"手动刷新才有 controller" |
| 预热分批次 + `requestIdleCallback` 兜底 | PHASE1=首屏非骨架资源 + 学习页资源；PHASE2=模考/练习/卡片/试题等重型页资源 |

### [js/app.js] SW ready 挂起修复 + 双保险监听
| 变化 | 说明 |
|---|---|
| `ready.then` + 3s 硬超时 | `ready` 超过 3s 未 settled 视为挂起 → 直接 `getRegistrations()` 绑定 updatefound |
| 分离 `wireUpdateFound` / `trackWorker` | 已在 installing 的 worker 也会被跟踪（首次 register 立刻入 install 场景） |
| `controllerchange` 再次绑定 | SW claim 后 controller 变化也会重新绑监听，不丢任何一个 updatefound |
| banner DOM 插入延后 | `requestAnimationFrame`+`setTimeout(0)`，不抢占首屏渲染 |

### [index.html] 防 FOUC/CLS 内联 + 首屏骨架 + SW 注册提前
| 变化 | 说明 |
|---|---|
| viewport 补齐 | `width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, viewport-fit=cover` |
| `<head>` 内联 CSS | `html/body` 立刻 `width:100%`/`min-height:100vh`/`overflow-x:hidden`，根容器 `width:100%`，不等待外部 CSS |
| 字体 fallback 堆叠 | 与霞鹜度量近似的系统 CJK 字体栈（PingFang SC / 微软雅黑 / 思源黑体…），替换时 CLS 尽可能小 |
| 同步主题初始化脚本 | `<head>` 内立即同步读 `localStorage` + `prefers-color-scheme` → 写 `data-theme`，首帧不会白闪 |
| `<body>` 顶部骨架遮罩 `#bq-boot-mask` | Logo + Spinner + 页面标题「BioQuest · 生物竞赛刷题」，在 JS/CSS 之前立刻渲染；三信号淡出（`DOMContentLoaded` / `window.load` / **5.5s 硬超时**），任何情况下不会永久遮罩 |
| SW 注册改 `DOMContentLoaded` | 不再等 `window.load`，避免被 woff2/图片抢占下载窗口 |
| 6s 超时 + 省流跳过 | SW register 6s 未 settle 就跳过；`saveData/2G/downlink<0.4Mbps` 直接跳过 SW 注册，低带宽用户首屏绝不拖慢 |

## 影响范围
- 新用户首次访问体验显著提升（install 从 ~150 文件降到 ~14 文件，不失败，立即 claim）。
- 移动端布局不再出现「先缩小→两边白边→撑满」的闪烁；主题无白闪。
- 低带宽 / 省流模式下不注册 SW，保持纯在线快速访问。
- 旧用户回跳：仅在 SW 更新后触发一次新版本提示 banner，其余行为不变。

## 验证方式
1. 在 DevTools Application → Service Workers 里勾选「Bypass for network / Update on reload」，模拟全新用户首访；确认 install 仅缓存 ~14 文件，controller 首次即出现，无需刷新。
2. 打开 Application → Clear storage → Clear，再刷首页；应看到骨架遮罩，不出现白边/缩小闪烁。
3. 切 2G/Slow 3G + 移动视口重复第 2 步；遮罩 5.5s 必消失，不永久遮挡。
4. 省流模式 / 低带宽（saveData 或 2G effectiveType）时控制台可见 `[SW] 低带宽/省流模式，跳过 SW 注册`，不影响页面渲染。

> Author: astrnox <astrnox@users.noreply.github.com>