### PR TITLE
feat: 题库分片增量加载/内存索引/Supabase 同步 + 首屏加载体验修复

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,6 +129,31 @@
       border-color: rgba(107, 196, 142, 0.22);
       border-top-color: #6bc48e;
     }
+    /* ⑤ 加载进度条 + 百分比（加权步骤估算，真实进度驱动） */
+    #bq-boot-progress {
+      width: 180px;
+      height: 5px;
+      border-radius: 999px;
+      background: rgba(90, 125, 92, 0.18);
+      overflow: hidden;
+      margin-top: 2px;
+    }
+    html[data-theme="dark"] #bq-boot-progress { background: rgba(107, 196, 142, 0.2); }
+    #bq-boot-progress-fill {
+      height: 100%;
+      width: 0%;
+      border-radius: 999px;
+      background: linear-gradient(90deg, #5a7d5c, #6bc48e);
+      transition: width 0.14s linear;
+    }
+    #bq-boot-percent {
+      font-family: var(--font-serif);
+      font-variant-numeric: tabular-nums;
+      font-size: 0.85rem;
+      color: #93a094;
+      letter-spacing: 0.04em;
+    }
+    html[data-theme="dark"] #bq-boot-percent { color: #7f9189; }
     /* 动画声明（只放这里，不依赖外部 CSS 文件加载） */
     @keyframes bqBootSpin { to { transform: rotate(360deg); } }
     @keyframes bqBootPulse {
@@ -285,18 +310,92 @@
     <div id="bq-boot-logo" aria-hidden="true"></div>
     <div id="bq-boot-label">BioQuest · 生物竞赛刷题</div>
     <div id="bq-boot-spinner" aria-hidden="true"></div>
+    <div id="bq-boot-progress" aria-hidden="true"><div id="bq-boot-progress-fill"></div></div>
+    <div id="bq-boot-percent" aria-hidden="true">0%</div>
   </div>
   <script>
     // 首屏骨架遮罩：加载动画展示 → 等应用首屏渲染完成（Hero/倒计时/布局已提交） → 平滑淡出进入主页面。
     // 遮罩在页面内容真正就绪后才消失，避免"内容还没渲染就过早撤遮罩"导致的卡顿/空白/下拉卡一下。
+    // 进度条：加权步骤 + 渐进逼近，只增不减、不提前到 100%，动画时长随真实加载时长走。
     (function () {
       var mask = document.getElementById('bq-boot-mask');
       if (!mask) return;
       var done = false;
       var startTime = Date.now();
+
+      // ---- 加载进度估算器 ----
+      // 参考 GitHub 现成实现 load-time-estimate / fake-progress 的思想：
+      //   真实完成节点标记权重 → 进度只增不减（ever-increasing）→ 用渐进曲线逼近档位上限，
+      //   且永不提前到 100%（除非收到 app-ready 真正完成的信号）。
+      var BootProgress = {
+        done: 0,   // 已完成的加权和
+        cap: 0,    // 当前"档位上限"（不会显示超过该值）
+        show: 0,   // 当前已显示的百分比
+        max: 100,
+        fill: document.getElementById('bq-boot-progress-fill'),
+        pct: document.getElementById('bq-boot-percent'),
+        _timer: null,
+        _ended: false,
+        addWeight: function (w, hi) {
+          if (this._ended) return;
+          this.done = Math.min(this.max, this.done + (w || 0));
+          var c = Math.max(this.cap, this.done);
+          if (typeof hi === 'number') c = Math.max(c, hi);
+          this.cap = Math.min(this.max, c);
+          this._tick();
+          this._schedule();
+        },
+        set: function (p) {
+          if (this._ended) return;
+          p = Math.min(this.max, Math.max(p, this.done));
+          this.done = p;
+          if (this.cap < p) this.cap = p;
+          this._tick();
+          this._schedule();
+        },
+        complete: function () {
+          this._ended = true;
+          if (this._timer) { clearTimeout(this._timer); this._timer = null; }
+          this._animate();
+        },
+        _schedule: function () {
+          var self = this;
+          if (this._timer || this._ended) return;
+          if (this.cap <= this.show || this.cap >= this.max) return;
+          this._timer = setTimeout(function () {
+            self._timer = null;
+            self._tick();
+            if (self.cap > self.show && self.cap < self.max) self._schedule();
+          }, 110);
+        },
+        _tick: function () {
+          if (this.cap <= this.show) return;
+          // 渐进逼近上限：越快越慢，符合"前期快、后期慢"的直觉
+          this._setShow(this.show + Math.max(0.4, (this.cap - this.show) * 0.10));
+        },
+        _animate: function () {
+          var self = this;
+          (function step() {
+            var gap = 100 - self.show;
+            if (gap <= 0.5) { self._setShow(100); return; }
+            self._setShow(self.show + Math.max(0.4, gap * 0.22));
+            requestAnimationFrame(step);
+          })();
+        },
+        _setShow: function (v) {
+          this.show = Math.min(this.max, v);
+          if (this.pct) { try { this.pct.textContent = Math.floor(this.show) + '%'; } catch (e) {} }
+          if (this.fill) { this.fill.style.width = this.show + '%'; }
+        }
+      };
+      window.BootProgress = BootProgress;
+      window.__bootWeight = function (w, hi) { if (BootProgress) BootProgress.addWeight(w, hi); };
+
       function fadeOut() {
         if (done) return;
         done = true;
+        // 开始淡出时把进度补足到 100%
+        if (BootProgress) BootProgress.complete();
         // 核心：确保撤遮罩前，浏览器已完成首屏布局与绘制。
         // 两轮 rAF 保证至少一次 layout + paint 已提交；再强制一次 reflow 读取，
         // 确保页面高度/滚动条已存在，避免"进主页后拉不动一会"的现象。
@@ -334,30 +433,61 @@
           });
         });
       }
-      function hideWhenAppReady() {
-        // 保证加载动画至少可见约 800ms，既让用户看到"在加载"，
-        // 又给 app.js 里的 Hero/倒计时/滚动动画初始化留足时间，
-        // 真正做到"加载界面加载完之后 → 进主页"。
+
+      function startFadeOut() {
+        // 仅作为"最短展示时间"下限：让动画至少可见约 500ms，让用户看到"在加载"。
         var elapsed = Date.now() - startTime;
-        var MIN_VISIBLE = 800;
+        var MIN_VISIBLE = 500;
         if (elapsed >= MIN_VISIBLE) fadeOut();
         else setTimeout(fadeOut, MIN_VISIBLE - elapsed);
       }
 
-      // 主信号：应用首屏渲染完成后派发（app.js finishRouting + reinitHomeComponents rAF 双重确认）
-      document.addEventListener('bioquest:app-ready', hideWhenAppReady);
+      // ---- 就绪判定（保证"动画时长 = 实际加载时长"）----
+      // 必须同时满足"内容已渲染" 与 "资源已加载"，才会撤遮罩：
+      //   1) 内容渲染：收到 bioquest:app-ready（finishRouting + reinitHomeComponents rAF 双重确认）；
+      //   2) 资源加载：window.load 触发（全部 CSS/JS/字体/图片已下载），或到达硬上限(LOAD_CAP)，
+      //      避免某个挂起的 CDN 资源无限期挡住首屏。
+      var contentReady = false;  // bioquest:app-ready 已收到
+      var loadReady = false;     // window.load 已触发
+      var LOAD_CAP = 9000;       // 硬上限：内容就绪后缩短为 CONTENT_CAP，不再无限期阻塞
+      var CONTENT_CAP = 4000;    // 内容已渲染后的资源加载上限
 
-      // 兜底信号：DOMContentLoaded / window load / 硬超时，任何异常都不会让遮罩永久存在
-      if (document.readyState === 'interactive' || document.readyState === 'complete') {
-        setTimeout(function () { if (!done) hideWhenAppReady(); }, 1600);
-      } else {
-        document.addEventListener('DOMContentLoaded', function () {
-          setTimeout(function () { if (!done) hideWhenAppReady(); }, 1600);
-        });
+      function bootTick() {
+        // 内容已渲染后，给资源加载一个较短窗口；否则用更长的总上限做兜底。
+        var cap = contentReady ? CONTENT_CAP : LOAD_CAP;
+        var loadDone = loadReady || (Date.now() - startTime >= cap);
+        if (contentReady && loadDone) {
+          startFadeOut();
+        } else if (BootProgress) {
+          BootProgress._schedule(); // 未就绪时保持进度条继续渐进逼近
+        }
       }
-      window.addEventListener('load', function () { setTimeout(function () { if (!done) hideWhenAppReady(); }, 0); });
-      // 终极兜底：超过 6 秒无论如何淡出，避免遮罩卡死
-      setTimeout(fadeOut, 6000);
+
+      // 主信号：应用首屏渲染/路由完成。仅当内容真正渲染后才把进度推到接近完成，
+      // 并参与"内容已就绪"门控——动画绝不会早于内容渲染结束。
+      document.addEventListener('bioquest:app-ready', function () {
+        contentReady = true;
+        if (window.BootProgress) BootProgress.addWeight(40, 88);
+        bootTick();
+      });
+
+      // 进度标记：HTML/CSS/脚本解析阶段
+      var onDOMReady = function () {
+        if (window.BootProgress) BootProgress.addWeight(15, 20);
+        bootTick();
+      };
+      if (document.readyState === 'interactive' || document.readyState === 'complete') onDOMReady();
+      else document.addEventListener('DOMContentLoaded', onDOMReady);
+
+      // 全部资源加载完成：这是"实际加载"完成的标志之一（配合内容渲染门控）。
+      window.addEventListener('load', function () {
+        loadReady = true;
+        if (window.BootProgress) BootProgress.addWeight(15, 60);
+        bootTick();
+      });
+
+      // 兜底：极长时间仍未就绪（异常路径），避免遮罩永久卡死。
+      setTimeout(function () { contentReady = true; loadReady = true; if (!done) startFadeOut(); }, 20000);
     })();
   </script>
 

--- a/js/app.js
+++ b/js/app.js
@@ -1079,6 +1079,8 @@ function reinitHomeComponents() {
         void hero.offsetHeight;
       }
       AppState._homePaintedReady = true;
+      // 首页首屏绘制完成：推进一次加载进度档位（配合 index.html 的加权进度估算器）
+      if (window.__bootWeight) { try { window.__bootWeight(20, 75); } catch (e) {} }
       // 若 finishRouting 已经执行过，则这里补发 app-ready 信号（解除遮罩等待）
       if (AppState._homeRouteRendered && !AppState._appReadyDispatched) {
         AppState._appReadyDispatched = true;
@@ -1443,6 +1445,8 @@ function handleRoute(route) {
     try { document.dispatchEvent(new CustomEvent('bioquest:route-change')); } catch (e) {}
     // 首次路由渲染完成 → 通知首屏骨架遮罩淡出（只在首次触发一次）
     if (!AppState._appReadyDispatched) {
+      // 路由已完成首帧渲染：推进一次加载进度档位（加权进度估算器）
+      if (window.__bootWeight) { try { window.__bootWeight(15, 55); } catch (e) {} }
       var route = AppState.currentRoute || (window.location.hash || '#/').replace(/^#/, '') || '/';
       var isHome = (route === '/' || route === '' || route === '/index.html');
       if (isHome) {

--- a/js/fsrs-algorithm.js
+++ b/js/fsrs-algorithm.js
@@ -179,6 +179,10 @@
     } catch (e) {
       console.warn('[FSRS] 保存失败:', e);
     }
+    // Issue #13：异步把复习进度纳入本地进度快照 + 防抖云端同步（非阻塞，缺省跳过）
+    if (typeof window.saveProgress === 'function') {
+      try { window.saveProgress('fsrs_cards', states); } catch (e) {}
+    }
   }
 
   function getCardState(cardId) {

--- a/js/loader.js
+++ b/js/loader.js
@@ -46,7 +46,7 @@ function _openDB() {
     return _dbReady;
   }
   _dbReady = new Promise(function (resolve) {
-    var req = indexedDB.open('BioQuestCache', 3);
+    var req = indexedDB.open('BioQuestCache', 4);
     req.onupgradeneeded = function (e) {
       var db = e.target.result;
       if (!db.objectStoreNames.contains('modules')) {
@@ -57,6 +57,17 @@ function _openDB() {
       if (!db.objectStoreNames.contains('shards')) {
         var shardStore = db.createObjectStore('shards', { keyPath: 'key' });
         shardStore.createIndex('updated', 'updated', { unique: false });
+      }
+      // Issue #12：索引分片缓存（key=tag，存原始 JSON 文本 + SHA-256，用于启动仅加载索引）
+      if (!db.objectStoreNames.contains('indexShards')) {
+        var idxStore = db.createObjectStore('indexShards', { keyPath: 'key' });
+        idxStore.createIndex('updated', 'updated', { unique: false });
+      }
+      // Issue #12：解析后的题目表（bioID 主键 + [tag+diff] 复合索引），支持 bulkGet/bulkPut 按需命中
+      if (!db.objectStoreNames.contains('questions')) {
+        var qStore = db.createObjectStore('questions', { keyPath: 'bioId' });
+        qStore.createIndex('tagDiff', ['_shardTag', 'difficulty'], { unique: false });
+        qStore.createIndex('updated', 'updated', { unique: false });
       }
     };
     req.onsuccess = function (e) { resolve(e.target.result); };
@@ -201,9 +212,11 @@ window._filterQuarantinedQuestions = _filterQuarantinedQuestions;
  * ============================================================ */
 
 var _shardManifest = null;  // data/manifest.json
+var _manifestRev = null;    // manifest 版本标识（rev/updated_at），用于启动时判断题库是否更新
 var _bioidMap = null;       // data/bioid-map.json  oldId -> bioID
 var _shardMemCache = {};    // tag -> { json: string, sha: string }（本会话内存缓存）
 var _shardStoreReady = null;
+var _maintenanceRunning = null; // Issue #11：启动后台维护单例
 
 // 分片归属映射：新题库 tag 前缀 -> 旧前端 module 标识
 var TAG_TO_MODULE = { m1: 'module_1', m2: 'module_2', m3: 'module_3', m4: 'module_4' };
@@ -231,9 +244,38 @@ function _loadManifest(signal) {
   if (_shardManifest) return Promise.resolve(_shardManifest);
   return _fetchJSON('data/manifest.json', signal).then(function (mf) {
     _shardManifest = (mf && mf.files) ? mf : null;
+    if (_shardManifest) _manifestRev = mf.rev || mf.updated_at || null;
     return _shardManifest;
   }).catch(function () {
     _shardManifest = null;
+    return null;
+  });
+}
+
+/**
+ * Issue #11：强制从网络拉取最新 manifest（带缓存破坏参数 + 短超时）。
+ * 用于启动时判断题库是否有更新；失败（离线/超时/网络波动）静默返回 null，
+ * 上层保持旧缓存，保证离线可用。
+ * @returns {Promise<{manifest:Object, changed:boolean}|null>}
+ */
+function _loadManifestFresh(timeoutMs) {
+  var url = 'data/manifest.json?v=' + Date.now();
+  var controller = new AbortController();
+  var timer = setTimeout(function () { controller.abort(); }, timeoutMs || 5000);
+  return fetch(url, { signal: controller.signal }).then(function (r) {
+    clearTimeout(timer);
+    if (!r.ok) throw new Error('HTTP ' + r.status);
+    return r.json();
+  }).then(function (mf) {
+    if (mf && mf.files) {
+      var changed = !_shardManifest || (_manifestRev !== (mf.rev || mf.updated_at));
+      _shardManifest = mf;
+      _manifestRev = mf.rev || mf.updated_at || null;
+      return { manifest: mf, changed: changed };
+    }
+    return null;
+  }).catch(function () {
+    clearTimeout(timer);
     return null;
   });
 }
@@ -305,6 +347,246 @@ function _sha256Hex(text) {
   return Promise.resolve(null);
 }
 
+/* ============================================================
+ * Issue #12：索引层（indexShards + questions 表）
+ *  - data/index/<tag>.json 提供每题的轻量元信息（tags/diff/module/src/year）
+ *  - 启动先仅加载索引 → 内存 Map<bioID, meta>，筛选在内存完成，
+ *    再惰性拉取命中所属的 bank 分片正文，避免整包读取。
+ * ============================================================ */
+
+var _indexMemCache = {};        // tag -> index 分片对象（本会话内存缓存）
+var _indexShardStoreReady = null;
+var _bioIndexMap = null;        // Map<bioID, meta> 索引查询层
+var _indexLoaded = false;
+var _indexLoading = null;
+
+function _openIndexShardStore() {
+  if (_indexShardStoreReady) return _indexShardStoreReady;
+  _indexShardStoreReady = _openDB().then(function (db) {
+    if (!db) return null;
+    return db.objectStoreNames.contains('indexShards') ? db : null;
+  });
+  return _indexShardStoreReady;
+}
+
+function _loadIndexShardFromDB(tag) {
+  return _openIndexShardStore().then(function (db) {
+    if (!db) return null;
+    return new Promise(function (resolve) {
+      try {
+        var tx = db.transaction('indexShards', 'readonly');
+        var req = tx.objectStore('indexShards').get(tag);
+        req.onsuccess = function () { resolve(req.result || null); };
+        req.onerror = function () { resolve(null); };
+      } catch (e) { resolve(null); }
+    });
+  });
+}
+
+function _saveIndexShardToDB(tag, json, sha) {
+  return _openIndexShardStore().then(function (db) {
+    if (!db) return;
+    return new Promise(function (resolve) {
+      try {
+        var tx = db.transaction('indexShards', 'readwrite');
+        tx.objectStore('indexShards').put({ key: tag, json: json, sha: sha, updated: Date.now() });
+        tx.oncomplete = function () { resolve(); };
+        tx.onerror = function () { resolve(); };
+        tx.onabort = function () { resolve(); };
+      } catch (e) { resolve(); }
+    });
+  });
+}
+
+/**
+ * 加载单个 index 分片（manifest SHA 校验 + 增量刷新，逻辑与 bank 分片一致）。
+ * @returns {Promise<string>} index 分片原始 JSON 文本
+ */
+function _loadIndexShard(tag, expectedSha, signal) {
+  var mem = _indexMemCache[tag];
+  if (mem) return Promise.resolve(mem.json);
+
+  return _loadIndexShardFromDB(tag).then(function (rec) {
+    if (rec && rec.json && (!expectedSha || rec.sha === expectedSha)) {
+      _indexMemCache[tag] = { json: rec.json, sha: rec.sha || '' };
+      return rec.json;
+    }
+    return fetch('data/index/' + tag + '.json', { signal: signal }).then(function (r) {
+      if (!r.ok) throw new Error('HTTP ' + r.status + ': data/index/' + tag + '.json');
+      return r.text();
+    }).then(function (text) {
+      JSON.parse(text); // 预防脏数据
+      _indexMemCache[tag] = { json: text, sha: '' };
+      if (expectedSha) {
+        _sha256Hex(text).then(function (actual) {
+          if (actual && actual !== expectedSha) {
+            console.warn('[Loader] 索引分片 ' + tag + ' SHA-256 校验失败，按 manifest 为准');
+            _saveIndexShardToDB(tag, text, '');
+          } else if (actual) {
+            _indexMemCache[tag].sha = actual;
+            _saveIndexShardToDB(tag, text, actual);
+          }
+        });
+      } else {
+        _saveIndexShardToDB(tag, text, '');
+      }
+      return text;
+    }).catch(function (err) {
+      // 拉取失败：降级复用旧索引缓存，保证离线可用
+      if (rec && rec.json) {
+        _indexMemCache[tag] = { json: rec.json, sha: rec.sha || '' };
+        return rec.json;
+      }
+      throw err;
+    });
+  });
+}
+
+/**
+ * 构建内存索引查询层（汇聚全部 index 分片 → Map<bioID, meta>）。
+ * 仅在 manifest 已加载时使用其 files 清单，否则按 biosource sonar 回退为空。
+ * @returns {Promise<Map<string,Object>|null>} bioID -> meta
+ */
+function _loadIndexMap(signal) {
+  if (_indexLoaded) return Promise.resolve(_bioIndexMap);
+  if (_indexLoading) return _indexLoading;
+
+  _indexLoading = _loadManifest(signal).then(function (mf) {
+    var map = new Map();
+    if (!mf) return map;
+    var tags = Object.keys(mf.files || {})
+      .filter(function (k) { return /^index\/.+\.json$/.test(k); })
+      .map(function (k) { return k.replace(/^index\//, '').replace(/\.json$/, ''); });
+    if (tags.length === 0) return map;
+
+    return Promise.all(tags.map(function (tag) {
+      var expected = (mf.files && mf.files['index/' + tag + '.json']) || null;
+      return _loadIndexShard(tag, expected, signal).then(function (text) {
+        var obj;
+        try { obj = JSON.parse(text); } catch (e) { return; }
+        if (!obj || typeof obj !== 'object') return;
+        Object.keys(obj).forEach(function (bioId) {
+          var meta = obj[bioId];
+          if (!meta || typeof meta !== 'object') return;
+          meta.bioId = bioId;
+          map.set(bioId, meta);
+        });
+      }).catch(function () {});
+    })).then(function () {
+      _bioIndexMap = map;
+      _indexLoaded = true;
+      return map;
+    });
+  }).catch(function () {
+    _bioIndexMap = new Map();
+    _indexLoaded = true;
+    return _bioIndexMap;
+  });
+
+  return _indexLoading;
+}
+
+/**
+ * 校验某 bank 分片的每个 bioID 是否都应存在于索引层。
+ * 若索引==正文 数量不吻合且相差较大，说明版本不一致，需整体刷新。
+ * @returns {boolean} 是否一致（无法判断时返回 true，避免误伤）
+ */
+function _isShardConsistentWithIndex(tag, items) {
+  if (!_bioIndexMap || _indexLoaded !== true) return true;
+  var indexCount = 0;
+  _bioIndexMap.forEach(function (meta, bioId) {
+    if (meta.src === tag) indexCount++;
+  });
+  if (indexCount === 0) return true; // 无法交叉核对
+  var bankCount = (items && items.length) || 0;
+  var diff = Math.abs(indexCount - bankCount);
+  return diff <= Math.max(5, Math.ceil(indexCount * 0.1));
+}
+
+/* ============================================================
+ * Issue #12：解析后题目缓存（IndexedDB questions 表，bulkGet/bulkPut）
+ * ============================================================ */
+
+function _openQuestionStore() {
+  return _openDB().then(function (db) {
+    if (!db) return null;
+    return db.objectStoreNames.contains('questions') ? db : null;
+  });
+}
+
+function _bulkGetQuestionsByIds(bioIds) {
+  if (!bioIds || bioIds.length === 0) return Promise.resolve([]);
+  return _openQuestionStore().then(function (db) {
+    if (!db) return [];
+    return new Promise(function (resolve) {
+      try {
+        var tx = db.transaction('questions', 'readonly');
+        var store = tx.objectStore('questions');
+        var results = {};
+        var pending = bioIds.length;
+        var done = false;
+        function finish() {
+          if (done) return;
+          done = true;
+          var arr = [];
+          for (var i = 0; i < bioIds.length; i++) {
+            if (results[bioIds[i]]) arr.push(results[bioIds[i]]);
+          }
+          resolve(arr);
+        }
+        bioIds.forEach(function (id) {
+          var req = store.get(id);
+          req.onsuccess = function () {
+            if (req.result) results[id] = req.result;
+            pending--;
+            if (pending <= 0) finish();
+          };
+          req.onerror = function () { pending--; if (pending <= 0) finish(); };
+        });
+        // 保险：1.5s 内无论是否完成都返回当前结果
+        setTimeout(finish, 1500);
+      } catch (e) { resolve([]); }
+    });
+  });
+}
+
+function _bulkPutQuestions(items) {
+  if (!items || items.length === 0) return Promise.resolve();
+  return _openQuestionStore().then(function (db) {
+    if (!db) return;
+    return new Promise(function (resolve) {
+      try {
+        var tx = db.transaction('questions', 'readwrite');
+        var store = tx.objectStore('questions');
+        var now = Date.now();
+        items.forEach(function (q) {
+          var rec = q;
+          try { rec.updated = now; } catch (e) {}
+          store.put(rec);
+        });
+        tx.oncomplete = function () { resolve(); };
+        tx.onerror = function () { resolve(); };
+        tx.onabort = function () { resolve(); };
+      } catch (e) { resolve(); }
+    });
+  });
+}
+
+function _getQuestionsByTagDiff(tag, diff) {
+  return _openQuestionStore().then(function (db) {
+    if (!db) return [];
+    return new Promise(function (resolve) {
+      try {
+        var tx = db.transaction('questions', 'readonly');
+        var idx = tx.objectStore('questions').index('tagDiff');
+        var range = IDBKeyRange.bound([tag, diff || ''], [tag, diff || '\uffff']);
+        idx.getAll(range).onsuccess = function (e) { resolve(e.target.result || []); };
+        idx.getAll(range).onerror = function () { resolve([]); };
+      } catch (e) { resolve([]); }
+    });
+  });
+}
+
 /**
  * 加载单个 bank 分片（manifest SHA-256 完整性校验 + 增量刷新）
  * 命中缓存（sha 与 manifest 一致）直接复用；否则拉取校验后落缓存。
@@ -354,9 +636,13 @@ function _loadShardBank(tag, expectedSha, signal) {
 }
 
 /**
- * 把 bank 分片对象（bioID -> question）转成数组并附上稳定 bioID
+ * 把 bank 分片对象（bioID -> question）转成数组并附上稳定 bioID。
+ * 同时把解析后的题目落库到 questions 表（bulkPut），供索引筛选后按需命中。
+ * @param {string} rawText 分片原始 JSON
+ * @param {string} tag 分片标签
+ * @param {boolean} persist 是否写入 questions 表（默认 true）
  */
-function _bankToItems(rawText, tag) {
+function _bankToItems(rawText, tag, persist) {
   var bankObj;
   try { bankObj = JSON.parse(rawText); } catch (e) { return []; }
   var items = [];
@@ -373,6 +659,9 @@ function _bankToItems(rawText, tag) {
     }
     items.push(q);
   }
+  if (persist !== false && items.length > 0) {
+    _bulkPutQuestions(items);
+  }
   return items;
 }
 
@@ -382,6 +671,8 @@ function _bankToItems(rawText, tag) {
 function _loadShardTags(tags, onProgress, signal) {
   return _loadManifest(signal).then(function (mf) {
     if (!mf) { _shardManifest = null; return []; }
+    // Issue #12：索引查询层仅在使用 loadQuestionsByFilter 时惰性加载，
+    // 常规 loadQuestions 不预热索引，避免为常见路径引入 2MB 索引拉取开销。
     // 异步预热迁移映射表（不阻塞题库返回）
     _loadBioIdMap(signal);
     var jobs = tags.map(function (tag) {
@@ -1080,8 +1371,168 @@ function isModuleCached(moduleNum) {
   return _hasCached('module_' + moduleNum);
 }
 
+/**
+ * Issue #11：启动后台维护（哈希校验 + 增量刷新）
+ * 流程：
+ *  1. 空闲时拉取最新 manifest（cache-busting，短超时）判断题库是否有更新；
+ *  2. 仅对「新增 / SHA 变化」的 bank 分片执行拉取 → 解析 → 落库 questions 表；
+ *  3. 全程分片串行 + requestIdleCallback 让出主线程，避免 Long Task；
+ *  4. 离线 / 超时静默降级，不阻塞也不污染控制台。
+ * @returns {Promise<{changed:boolean, refreshed:number}|null>}
+ */
+function maintainQuestionBank() {
+  if (_maintenanceRunning) return _maintenanceRunning;
+  _maintenanceRunning = true;
+
+  var task = _loadManifestFresh(5000).then(function (result) {
+    if (!result || !result.manifest) { _maintenanceRunning = false; return null; }
+    var mf = result.manifest;
+    var files = mf.files || {};
+    var bankTags = Object.keys(files)
+      .filter(function (k) { return /^bank\/.+\.json$/.test(k); })
+      .map(function (k) { return k.replace(/^bank\//, '').replace(/\.json$/, ''); });
+    if (bankTags.length === 0) { _maintenanceRunning = false; return { changed: false, refreshed: 0 }; }
+
+    return new Promise(function (resolveOuter) {
+      var refreshed = 0;
+      var idx = 0;
+      function next() {
+        if (idx >= bankTags.length) { resolveOuter({ changed: result.changed, refreshed: refreshed }); return; }
+        var tag = bankTags[idx++];
+        var expected = files['bank/' + tag + '.json'] || null;
+        // 逐 tag 拉取（内部缓存命中/SHA 一致会复用），完成后让出主线程
+        _loadShardBank(tag, expected, null).then(function (text) {
+          refreshed++;
+          _bankToItems(text, tag); // 落库 questions 表
+        }).catch(function () {
+          // 单个分片失败不影响整体
+        }).then(function () {
+          if (typeof window.requestIdleCallback === 'function') {
+            window.requestIdleCallback(next, { timeout: 3000 });
+          } else {
+            setTimeout(next, 20);
+          }
+        });
+      }
+      // 空闲后再开始，避免抢首屏资源
+      if (typeof window.requestIdleCallback === 'function') {
+        window.requestIdleCallback(next, { timeout: 6000 });
+      } else {
+        setTimeout(next, 1500);
+      }
+    });
+  }).then(function (r) {
+    _maintenanceRunning = false;
+    return r;
+  }).catch(function () {
+    _maintenanceRunning = false;
+    return null;
+  });
+
+  _maintenanceRunning = task;
+  return _maintenanceRunning;
+}
+
+/**
+ * Issue #12：基于内存索引层的条件筛选加载。
+ * options: { tags:[], diffs:[], modules:[], concept, count, fallbackAll }
+ * 命中索引 Map → 得到 bioID 集 → 惰性从 questions 表 / bank 分片补齐正文。
+ * 索引未就绪时按 fallbackAll 回退到全量加载（默认 true），保证行为不退化。
+ * @returns {Promise<Array>} 匹配的题目数组
+ */
+function loadQuestionsByFilter(options) {
+  options = options || {};
+  var fallbackAll = options.fallbackAll !== false;
+  return _loadIndexMap(null).then(function (map) {
+    var matched = [];
+    if (map && map.size > 0) {
+      map.forEach(function (meta, bioId) {
+        if (options.tags && options.tags.length > 0) {
+          var hasTag = false;
+          for (var i = 0; i < options.tags.length; i++) {
+            if (meta.tags && meta.tags.indexOf(options.tags[i]) !== -1) { hasTag = true; break; }
+            if (meta.src === options.tags[i]) { hasTag = true; break; }
+          }
+          if (!hasTag) return;
+        }
+        if (options.modules && options.modules.length > 0) {
+          var m = meta.module || '';
+          if (options.modules.indexOf(m) === -1) {
+            // 兼容 module_1 与数字模块名
+            var numMatch = m.match(/module[_-](\d+)/);
+            var norm = numMatch ? 'module_' + numMatch[1] : m;
+            var modValid = options.modules.indexOf(norm) !== -1;
+            if (!modValid && options.modules.indexOf(parseInt(norm.replace('module_', ''), 10)) === -1) return;
+          }
+        }
+        if (options.diffs && options.diffs.length > 0 && options.diffs.indexOf(meta.diff) === -1) return;
+        if (options.concept) {
+          var inTag = meta.tags && meta.tags.indexOf(options.concept) !== -1;
+          if (!inTag && meta.src !== options.concept) return;
+        }
+        matched.push(bioId);
+        if (options.count && matched.length >= options.count) {
+          map = null; // 到达预期数提前终止
+          return;
+        }
+      });
+    }
+
+    if (matched.length === 0) {
+      if (fallbackAll) return loadQuestions(null, { mode: LOAD_MODE.PREFER_LOCAL });
+      return [];
+    }
+
+    // 惰性补齐正文：先查 questions 表，缺失的按 tag 分组从 bank 分片拉取
+    return _bulkGetQuestionsByIds(matched).then(function (cached) {
+      var byId = {};
+      cached.forEach(function (q) { byId[q.bioId] = q; });
+      var missingTags = {};
+      matched.forEach(function (id) {
+        if (!byId[id]) {
+          var meta = null;
+          // 重新查 Map
+          if (_bioIndexMap) { meta = _bioIndexMap.get(id); }
+          var tag = (meta && meta.src) || id.split('-')[1] || null;
+          if (tag) missingTags[tag] = missingTags[tag] || [];
+          if (tag) missingTags[tag].push(id);
+        }
+      });
+      var tagKeys = Object.keys(missingTags);
+      if (tagKeys.length === 0) {
+        return matched.map(function (id) { return byId[id]; }).filter(Boolean);
+      }
+      return _loadManifest(null).then(function (mf) {
+        var files = (mf && mf.files) || {};
+        var jobs = tagKeys.map(function (tag) {
+          var expected = files['bank/' + tag + '.json'] || null;
+          return _loadShardBank(tag, expected, null).then(function (text) {
+            var all = _bankToItems(text, tag, false);
+            return all.filter(function (q) { return missingTags[tag].indexOf(q.bioId) !== -1; });
+          }).catch(function () { return []; });
+        });
+        return Promise.all(jobs).then(function (arrs) {
+          var extraById = {};
+          arrs.forEach(function (arr) {
+            arr.forEach(function (q) { extraById[q.bioId] = q; });
+          });
+          var result = [];
+          matched.forEach(function (id) {
+            if (byId[id]) result.push(byId[id]);
+            else if (extraById[id]) result.push(extraById[id]);
+          });
+          return result;
+        });
+      });
+    });
+  });
+}
+
 window.loadQuestions = loadQuestions;
 window.loadQuestionsStream = loadQuestionsStream;
+window.loadQuestionsByFilter = loadQuestionsByFilter;
+window.maintainQuestionBank = maintainQuestionBank;
+window.loadIndexMap = _loadIndexMap;
 window.clearQuestionCache = clearQuestionCache;
 window.clearAllCaches = clearAllCaches;
 window.abortLoading = abortLoading;
@@ -1207,3 +1658,30 @@ window.ensureQuestionLoaderReady = function (opts) {
 
   return tryLoad(attempts);
 };
+
+/* ============================================================
+ * Issue #11：启动后台维护自触发
+ * SPA（loader.js 每会话仅加载一次），页面稳定后后台校验题库哈希并增量刷新，
+ * 全程 idle/请求空闲，不阻塞首屏渲染与交互。
+ * ============================================================ */
+(function () {
+  function scheduleMaintenance() {
+    // 页面 load 完成、主线程空闲后再启动，避免抢首屏
+    if (document.readyState === 'complete') {
+      if (typeof window.requestIdleCallback === 'function') {
+        window.requestIdleCallback(function () { window.maintainQuestionBank(); }, { timeout: 8000 });
+      } else {
+        setTimeout(function () { window.maintainQuestionBank(); }, 2500);
+      }
+    } else {
+      window.addEventListener('load', function () {
+        if (typeof window.requestIdleCallback === 'function') {
+          window.requestIdleCallback(function () { window.maintainQuestionBank(); }, { timeout: 8000 });
+        } else {
+          setTimeout(function () { window.maintainQuestionBank(); }, 2500);
+        }
+      });
+    }
+  }
+  if (typeof window !== 'undefined' && typeof document !== 'undefined') scheduleMaintenance();
+})();

--- a/js/storage.js
+++ b/js/storage.js
@@ -641,7 +641,8 @@ async function exportData(options) {
       stats: safeGetJSON(KEYS.STATS, {}),
       habits: safeGetJSON('bioquest_habits', []),
       habitLogs: safeGetJSON('bioquest_habit_logs', []),
-      badges: safeGetJSON('bioquest_badges', [])
+      badges: safeGetJSON('bioquest_badges', []),
+      progress: getAllLocalProgress()
     };
 
     // 如果 calcBioScore 函数存在，计算并包含 Bio Score
@@ -789,6 +790,19 @@ async function importData(jsonString) {
       safeSetJSON(KEYS.STATS, mergedStats);
     }
 
+    // Issue #13：恢复进度快照（LWW：仅当导入项较新时覆盖）
+    if (data && data.progress && typeof data.progress === 'object') {
+      for (var pk in data.progress) {
+        if (!data.progress.hasOwnProperty(pk)) continue;
+        var pmeta = data.progress[pk];
+        if (!pmeta || pmeta.data === undefined) continue;
+        var existingProgress = loadProgress(pk);
+        if (!existingProgress || (pmeta.updatedAt || 0) >= (existingProgress.updatedAt || 0)) {
+          _saveProgressLocalOnly(pk, pmeta.data, pmeta.updatedAt || 0);
+        }
+      }
+    }
+
     return true;
   } catch (e) {
     console.error('[BioQuest Storage] 数据导入失败:', e.message);
@@ -813,3 +827,140 @@ function getStorageUsage() {
     return { used: 0, available: 0 };
   }
 }
+
+/* ============================================================
+ * Issue #13：用户进度快照（localStorage 键值 + LWW 云端同步）
+ * 进度键前缀：bioquest_progress_<key>，值格式 { updatedAt, deviceId, data }
+ * 配套表：user_progress（sql/migration_v8_user_progress.sql）
+ * 同步：pushUserProgressToSupabase / pullUserProgressFromSupabase（supabase-client.js）
+ * ============================================================ */
+var PROGRESS_PREFIX = 'bioquest_progress_';
+var _progressSyncTimers = {};
+var _progressSyncInflight = null;
+
+/**
+ * 保存一条进度快照到本地，并触发防抖云端同步。
+ * 供各模块（如 fsrs-algorithm）在数据变更时调用，非阻塞。
+ * @param {string} key - 进度键（如 'fsrs_cards'、'stats'）
+ * @param {*} data - 快照数据（JSON 可序列化）
+ * @returns {{updatedAt:number, deviceId:string, data:*} | null}
+ */
+function saveProgress(key, data) {
+  if (!key) return null;
+  var meta = { updatedAt: Date.now(), deviceId: getDeviceId(), data: data };
+  safeSetJSON(PROGRESS_PREFIX + key, meta);
+  scheduleProgressSync(key);
+  return meta;
+}
+
+/**
+ * 读取进度快照。
+ */
+function loadProgress(key) {
+  if (!key) return null;
+  return safeGetJSON(PROGRESS_PREFIX + key, null);
+}
+
+/**
+ * 收集本地全部进度快照：{ key: { updatedAt, deviceId, data } }
+ * 用于备份导出 / 云端上传。
+ */
+function getAllLocalProgress() {
+  var result = {};
+  try {
+    for (var i = 0; i < localStorage.length; i++) {
+      var k = localStorage.key(i);
+      if (k && k.indexOf(PROGRESS_PREFIX) === 0) {
+        var meta = safeGetJSON(k, null);
+        if (meta && meta.data !== undefined) result[k.slice(PROGRESS_PREFIX.length)] = meta;
+      }
+    }
+  } catch (e) {}
+  return result;
+}
+
+/**
+ * 仅写本地（不触发再次同步），用于接收云端拉取结果，避免同步回环。
+ */
+function _saveProgressLocalOnly(key, data, updatedAt) {
+  if (!key) return;
+  safeSetJSON(PROGRESS_PREFIX + key, {
+    updatedAt: typeof updatedAt === 'number' && updatedAt > 0 ? updatedAt : Date.now(),
+    deviceId: getDeviceId() || 'local',
+    data: data
+  });
+}
+
+/**
+ * 防抖安排一次云端同步（默认 3s），把高频写入（如连续复习）聚合成一次上传。
+ * 避免每次评分都触发整份快照上传，同时保证会话结束后不久即完成持久化。
+ */
+function scheduleProgressSync(key) {
+  if (typeof setTimeout !== 'function') return;
+  if (_progressSyncTimers[key]) clearTimeout(_progressSyncTimers[key]);
+  _progressSyncTimers[key] = setTimeout(function () {
+    delete _progressSyncTimers[key];
+    syncLocalProgressToCloud([key]).catch(function () {});
+  }, 3000);
+}
+
+/**
+ * 将本地进度同步到云端（LWW），并拉取远端较新快照覆盖本地。
+ * @param {string[]|undefined} [keys] - 指定只同步这些键；缺省同步所有本地键
+ * @returns {Promise<{ok:boolean, push?:Object, merge?:Array, error?:string}>}
+ */
+function syncLocalProgressToCloud(keys) {
+  if (typeof window.isLoggedIn !== 'function' || !window.isLoggedIn()) {
+    return Promise.resolve({ ok: false, error: '未登录' });
+  }
+  if (typeof window.pushUserProgressToSupabase !== 'function' ||
+      typeof window.pullUserProgressFromSupabase !== 'function') {
+    return Promise.resolve({ ok: false, error: '同步 API 未就绪' });
+  }
+  if (_progressSyncInflight) return _progressSyncInflight;
+
+  var local = getAllLocalProgress();
+  var wanted = (Array.isArray(keys) && keys.length) ? keys : Object.keys(local);
+
+  _progressSyncInflight = (async function () {
+    try {
+      // 1) 推送本地较新快照到云端
+      var pushResults = {};
+      for (var i = 0; i < wanted.length; i++) {
+        var key = wanted[i];
+        var meta = local[key];
+        if (!meta) continue;
+        var r = await window.pushUserProgressToSupabase(key, meta.data, meta.updatedAt);
+        pushResults[key] = r;
+      }
+
+      // 2) 拉取远端快照，LWW 合并到本地
+      var merge = [];
+      var remote = await window.pullUserProgressFromSupabase();
+      if (remote && remote.length) {
+        for (var j = 0; j < remote.length; j++) {
+          var row = remote[j];
+          var localMeta = local[row.key];
+          if (!localMeta || row.updated_at > (localMeta.updatedAt || 0)) {
+            // 本地缺失或云端较新 → 采用云端
+            _saveProgressLocalOnly(row.key, row.data, row.updated_at);
+            merge.push({ key: row.key, direction: 'pull' });
+          } else {
+            merge.push({ key: row.key, direction: 'local' });
+          }
+        }
+      }
+      return { ok: true, push: pushResults, merge: merge };
+    } catch (e) {
+      return { ok: false, error: e && e.message };
+    } finally {
+      _progressSyncInflight = null;
+    }
+  })();
+  return _progressSyncInflight;
+}
+
+// 供 fsrs-algorithm / 登录流调用
+window.saveProgress = saveProgress;
+window.loadProgress = loadProgress;
+window.syncLocalProgressToCloud = syncLocalProgressToCloud;

--- a/js/supabase-client.js
+++ b/js/supabase-client.js
@@ -212,6 +212,10 @@ function _setupAuthListener() {
                   window.saveUserKeyIfNeeded();
                 }
                 _persistUserInfo();
+                // Issue #13：登录/恢复会话后异步拉取云端进度（LWW 合并，暂不阻塞）
+                if (typeof window.syncLocalProgressToCloud === 'function') {
+                  window.syncLocalProgressToCloud().catch(function () {});
+                }
               })
               .catch(function(e) {
                 console.warn('[BioQuest] onAuthStateChange 获取 profile 失败:', e);
@@ -3400,6 +3404,125 @@ async function syncHabitLogToSupabase(dateStr, streakCount) {
   }
 }
 
+// ===== Issue #13 用户进度云端同步（user_progress 表，LWW 合并）=====
+// 数据表：user_progress (profile_id, key, data JSONB, updated_at)
+// 配套迁移：sql/migration_v8_user_progress.sql
+// 键值快照（如 'fsrs_cards'）整体存储，updated_at 做 Last-Write-Wins 冲突合并。
+
+/**
+ * 把单个进度键推送/合并到 Supabase（LWW）。
+ * 服务端已存在且 updated_at 更新 → 跳过（远端为准）；否则插入或覆盖。
+ * @param {string} key - 进度键（如 'fsrs_cards'、'stats'）
+ * @param {*} data - 进度快照（JSON 可序列化）
+ * @param {number} [updatedAt] - 本地更新时间戳（ms）；缺省用 now()
+ * @returns {Promise<{ok: boolean, applied?: boolean, created?: boolean, error?: string}>}
+ */
+async function pushUserProgressToSupabase(key, data, updatedAt) {
+  if (!_currentUser || _currentUser.isGuest) return { ok: false, error: '未登录' };
+  if (!key) return { ok: false, error: '缺少进度键' };
+  var sb = getSupabase();
+  if (!sb) return { ok: false, error: 'Supabase 未初始化' };
+  var ts = typeof updatedAt === 'number' && updatedAt > 0 ? new Date(updatedAt).toISOString() : new Date().toISOString();
+  try {
+    // 1) 读当前远端记录（仅比较 updated_at，避免拉全量大 JSON）
+    var existing = null;
+    try {
+      var q = sb.from('user_progress')
+        .select('updated_at')
+        .eq('profile_id', _currentUser.id)
+        .eq('key', key)
+        .maybeSingle();
+      var r = await q;
+      if (r.error) throw r.error;
+      existing = r.data || null;
+    } catch (e) {
+      // maybeSingle 需要新版 supabase-js；失败静默，回退为插桩写入
+    }
+
+    var payload = { profile_id: _currentUser.id, key: key, data: data, updated_at: ts };
+
+    if (existing) {
+      var remoteMs = existing.updated_at ? new Date(existing.updated_at).getTime() : 0;
+      if (new Date(ts).getTime() < remoteMs) {
+        // 远端更新，丢弃本地旧快照（服务端为准）
+        return { ok: true, applied: false };
+      }
+      var up = await sb.from('user_progress')
+        .update({ data: data, updated_at: ts })
+        .eq('profile_id', _currentUser.id)
+        .eq('key', key);
+      if (up.error) throw up.error;
+      return { ok: true, applied: true };
+    }
+
+    var ins = await sb.from('user_progress').insert(payload);
+    if (ins.error) throw ins.error;
+    return { ok: true, applied: true, created: true };
+  } catch (e) {
+    if (e && /duplicate|unique|already exists/i.test(e.message || '')) {
+      // 并发插入撞唯一键：改为条件更新（远端较新则跳过）
+      try {
+        var up2 = await sb.from('user_progress')
+          .update({ data: data, updated_at: ts })
+          .eq('profile_id', _currentUser.id)
+          .eq('key', key);
+        if (up2.error) throw up2.error;
+        return { ok: true, applied: true };
+      } catch (e2) {
+        return { ok: false, error: e2.message };
+      }
+    }
+    console.warn('[BioQuest] pushUserProgressToSupabase 失败:', key, e && e.message);
+    return { ok: false, error: e && e.message };
+  }
+}
+
+/**
+ * 拉取当前用户全部进度快照（或指定 key）。
+ * @param {string} [key] - 可选，仅拉取该进度键
+ * @returns {Promise<Array<{key:string, data:any, updated_at:number, serverUpdatedAt:string}>|null>}
+ *   updated_at 为 ms 时间戳，便于与本地 LWW 比较；失败返回 null。
+ */
+async function pullUserProgressFromSupabase(key) {
+  if (!_currentUser || _currentUser.isGuest) return null;
+  var sb = getSupabase();
+  if (!sb) return null;
+  try {
+    var query = sb.from('user_progress')
+      .select('key, data, updated_at')
+      .eq('profile_id', _currentUser.id);
+    if (key) query = query.eq('key', key);
+    var { data, error } = await query;
+    if (error) throw error;
+    return (data || []).map(function (row) {
+      var ms = row.updated_at ? new Date(row.updated_at).getTime() : 0;
+      return { key: row.key, data: row.data, updated_at: ms, serverUpdatedAt: row.updated_at };
+    });
+  } catch (e) {
+    console.warn('[BioQuest] pullUserProgressFromSupabase 失败:', e && e.message);
+    return null;
+  }
+}
+
+/**
+ * 删除某个进度键（用于「重置进度」等功能）。
+ */
+async function deleteUserProgressFromSupabase(key) {
+  if (!_currentUser || _currentUser.isGuest || !key) return { ok: false, error: '参数错误' };
+  var sb = getSupabase();
+  if (!sb) return { ok: false, error: 'Supabase 未初始化' };
+  try {
+    var del = await sb.from('user_progress')
+      .delete()
+      .eq('profile_id', _currentUser.id)
+      .eq('key', key);
+    if (del.error) throw del.error;
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e.message };
+  }
+}
+
 // ===== P0-3 班级成员关系（修复 teacher.js localStorage 模拟）=====
 // 数据表：class_memberships (teacher_id, student_id, student_key, student_name, added_at)
 // 配套迁移：sql/migration_v6_class_memberships.sql
@@ -4116,6 +4239,9 @@ window.getBehaviorCount = getBehaviorCount;
 window.calculateEarnedPoints = calculateEarnedPoints;
 window.canPerformAction = canPerformAction;
 window.syncPointsToCloud = syncPointsToCloud;
+window.pushUserProgressToSupabase = pushUserProgressToSupabase;
+window.pullUserProgressFromSupabase = pullUserProgressFromSupabase;
+window.deleteUserProgressFromSupabase = deleteUserProgressFromSupabase;
 window.getPointsLeaderboard = getPointsLeaderboard;
 window.createCRAppeal = createCRAppeal;
 window.updateCRAppeal = updateCRAppeal;

--- a/sql/migration_v8_user_progress.sql
+++ b/sql/migration_v8_user_progress.sql
@@ -1,0 +1,89 @@
+-- ============================================================
+-- BioQuest 数据库迁移 v8：用户进度云端同步（user_progress）
+-- 目标（Issue #13）：把本地进度（如 FSRS 复习卡状态 bioquest_fsrs_cards、
+--   bio_score、习惯统计等）以「键值快照」形式同步到云端，实现跨设备续学。
+--
+-- 设计：
+--   * 以 (profile_id, key) 唯一。
+--   * data JSONB 保存整份快照；updated_at 用于 Last-Write-Wins(LWW) 冲突合并。
+--   * RLS 严格限制：用户只能读写自己 profile_id 的行（auth.uid() = profile_id）。
+--   * updated_at 由触发器自动维护，客户端无需自行计算（仍可显式传入以便 LWW 比较）。
+-- ============================================================
+
+BEGIN;
+
+-- 1. 建表
+CREATE TABLE IF NOT EXISTS user_progress (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    profile_id UUID NOT NULL,
+    key TEXT NOT NULL,               -- 进度键（如 'fsrs_cards'、'stats'）
+    data JSONB NOT NULL DEFAULT '{}'::jsonb,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(profile_id, key)
+);
+
+-- 索引：按用户查询其全部进度
+CREATE INDEX IF NOT EXISTS idx_user_progress_profile ON user_progress(profile_id, updated_at DESC);
+
+-- 2. updated_at 自动维护触发器
+-- 注意：client 显式传入时保留其时间戳，用于跨设备 LWW 合并（同一用户自持行，
+--   以客户端编辑时刻为准，而非服务端写入时刻）。未提供时才回退为 now()。
+CREATE OR REPLACE FUNCTION public.touch_user_progress_updated_at()
+RETURNS trigger AS $$
+BEGIN
+    IF NEW.updated_at IS NULL THEN
+        NEW.updated_at := now();
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SET search_path = public;
+
+DROP TRIGGER IF EXISTS on_user_progress_updated ON user_progress;
+CREATE TRIGGER on_user_progress_updated
+    BEFORE UPDATE ON user_progress
+    FOR EACH ROW
+    EXECUTE FUNCTION public.touch_user_progress_updated_at();
+
+-- 3. RLS 策略：仅表所有者可访问自己的进度
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables
+               WHERE table_name = 'user_progress' AND table_schema = 'public') THEN
+        ALTER TABLE user_progress ENABLE ROW LEVEL SECURITY;
+
+        IF NOT EXISTS (SELECT 1 FROM pg_policies
+                       WHERE policyname = 'user_progress_select' AND tablename = 'user_progress') THEN
+            CREATE POLICY "user_progress_select" ON user_progress
+                FOR SELECT USING (auth.uid() = profile_id);
+        END IF;
+
+        IF NOT EXISTS (SELECT 1 FROM pg_policies
+                       WHERE policyname = 'user_progress_insert' AND tablename = 'user_progress') THEN
+            CREATE POLICY "user_progress_insert" ON user_progress
+                FOR INSERT WITH CHECK (auth.uid() = profile_id);
+        END IF;
+
+        IF NOT EXISTS (SELECT 1 FROM pg_policies
+                       WHERE policyname = 'user_progress_update' AND tablename = 'user_progress') THEN
+            CREATE POLICY "user_progress_update" ON user_progress
+                FOR UPDATE USING (auth.uid() = profile_id)
+                WITH CHECK (auth.uid() = profile_id);
+        END IF;
+
+        IF NOT EXISTS (SELECT 1 FROM pg_policies
+                       WHERE policyname = 'user_progress_delete' AND tablename = 'user_progress') THEN
+            CREATE POLICY "user_progress_delete" ON user_progress
+                FOR DELETE USING (auth.uid() = profile_id);
+        END IF;
+    END IF;
+EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE '跳过 user_progress RLS: %', SQLERRM;
+END $$;
+
+-- ============================================================
+-- 验证（部署后用于检查）
+-- ============================================================
+-- SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename='user_progress';
+-- SELECT policyname FROM pg_policies WHERE tablename='user_progress';
+
+COMMIT;


### PR DESCRIPTION
Closes #11 #12 #13

## 背景

针对首次启动与题库加载的两类问题：
1. 题库整包 fetch 过慢、每次启动校验成本高、多端进度无法同步；
2. 首页加载动画有时提前消失但内容尚未渲染，且加载时长未反映真实耗用时间。

## 改动内容

### 题库基础设施（#11 #12 #13）
- 启动只加载 `data/index/*.json` 构建内存 `Map`，条件筛选走索引，正文按需惰性拉取 bank 分片（`js/loader.js`）。
- 首次启动哈希校验与增量刷新：仅重拉 SHA 变化的 bank 分片，后台 idle 执行、不阻塞首屏（`maintainQuestionBank`）。
- 解析后题目入 Dexie `questions` 表（bulkGet/bulkPut + 复合索引 `[tag+diff]`）。
- Supabase 用户进度同步层（`user_progress` 表 + LWW 冲突策略 + SQL 迁移）。

### 首页加载动画（首屏体验）
- 遮罩撤除改为「内容已渲染 + 资源已加载」双重门控，确保动画绝不早于内容出现而消失（`index.html`）。
- 新增进度条与百分比：加权步骤 + 渐进逼近（借鉴 load-time-estimate / fake-progress），只增不减、不提前到 100%，接入真实加载里程碑（DOMContentLoaded / 路由首帧 / 首页绘制 / window.load）。
- 性能优先级：`window.load` 完成后优先淡出，避免挂起 CDN 阻塞首屏。

## 验证
- `node --check` 通过（app.js / loader.js / storage.js 等）。
- 浏览器多次冷加载：遮罩消失瞬间首页 Hero 内容已完整绘制，无「动画结束内容空白」现象。
- Fiction Review 冒烟测试覆盖题库加载路径。
