### PR TITLE
fix(P1): AI Key 安全存储 / 数据合规导出删除 / 配额管理 / 隐私政策

### DIFF
--- a/index.html
+++ b/index.html
@@ -846,6 +846,7 @@
         <a href="#/analytics">学习分析</a>
         <a href="#/leaderboard">排行榜</a>
         <a href="#/user">用户中心</a>
+        <a href="#/privacy">隐私政策</a>
         <a href="resources.html">学习资源</a>
         <a href="javascript:void(0)" onclick="window.showFeedbackModal()" style="color:rgba(255,255,255,0.5);font-size:0.8rem;transition:color 0.15s">反馈</a>
         <a href="javascript:void(0)" onclick="window.checkForAppUpdates()" style="color:rgba(255,255,255,0.5);font-size:0.8rem;transition:color 0.15s" title="检查应用与题库更新">检查更新</a>
@@ -1012,8 +1013,10 @@
   </script> -->
 
   <!-- 核心模块直接加载，避免动态 import 兼容性问题 -->
+  <!-- ai-key-store.js 先行：提供加密/闭包化的 AI Key 存取（P1-3），供后续脚本使用 -->
+  <script src="js/ai-key-store.js?v=20260819a" defer></script>
   <!-- ai-client.js 先加载（纯前端 AI 调用，供 tutor/discussion 复用） -->
-  <script src="js/ai-client.js?v=20260809f" defer></script>
+  <script src="js/ai-client.js?v=20260819a" defer></script>
   <!-- v3.4 基础能力：事件总线 + IRT 引擎 + TTS + 白板 + 多智能体 -->
   <script src="js/event-bus.js?v=20260712k" defer></script>
   <script src="js/irt-engine.js?v=20260712k" defer></script>

--- a/js/ai-client.js
+++ b/js/ai-client.js
@@ -354,30 +354,19 @@
   }
 
   // 读取当前有效 API Key（仅内部使用，不对外返回）：
-  //   1) 优先读页面内存 window.__bioquest_ai_key_memory__（user.js 保存）；
-  //   2) 兼容迁移：若 localStorage 仍残留旧版明文 Key，搬进内存后立即擦除；
-  //   3) 都没有 → 返回空串，调用方走 canUse() 的配置引导。
+  //   P1-3 修复：统一走 window.BioQuestKeyStore 闭包单例读取。
+  //   该单例负责旧版 localStorage 明文迁移与「会话内记住」的恢复，
+  //   不再在 window 上暴露可直读的明文属性 window.__bioquest_ai_key_memory__。
   function _getApiKey() {
-    var MEM_KEY = '__bioquest_ai_key_memory__';
     try {
-      if (window && typeof window[MEM_KEY] === 'string' && _isValidKey(window[MEM_KEY])) {
-        return window[MEM_KEY];
+      if (typeof window.BioQuestKeyStore === 'object' && typeof window.BioQuestKeyStore.get === 'function') {
+        var k = window.BioQuestKeyStore.get();
+        return _isValidKey(k) ? k : '';
       }
     } catch (e) {}
+    // 兜底：极早期版本可能在 window 上残留明文（理论上已被 ai-key-store 迁移清除）
     try {
-      var raw = localStorage.getItem('bioquest_ai_key_config');
-      if (raw) {
-        var stored = JSON.parse(raw);
-        if (stored && _isValidKey(stored.apiKey)) {
-          var key = stored.apiKey;
-          try { window[MEM_KEY] = key; } catch (e2) {}
-          try {
-            stored.apiKey = '';
-            localStorage.setItem('bioquest_ai_key_config', JSON.stringify(stored));
-          } catch (e3) {}
-          return key;
-        }
-      }
+      if (window && typeof window.__bioquest_ai_key_memory__ === 'string') return window.__bioquest_ai_key_memory__;
     } catch (e) {}
     return '';
   }

--- a/js/ai-key-store.js
+++ b/js/ai-key-store.js
@@ -1,0 +1,97 @@
+/**
+ * ============================================================
+ * BioQuest — AI API Key 安全存取单例
+ * 【P1-3 修复】消除明文 Key 直接暴露在 window 全局的问题
+ *
+ * 设计要点：
+ *  1. Key 仅存在于本模块的闭包内存中，不再挂到 window 的普通可枚举属性上；
+ *  2. 对外仅暴露 get/set/clear/isRemember 接口，无接口外的明文读取面；
+ *  3. 提供「会话内记住」（用户显式勾选）：Key 额外写入 sessionStorage，
+ *     同一标签页内刷新可恢复，关闭标签页即清除，不落 localStorage、不入 git；
+ *  4. 兼容旧版：检测到 localStorage 中残留的明文 Key 时，搬入内存后立即擦除。
+ *
+ * 残余风险说明（评审需知）：
+ *  纯前端应用无法真正向页面自身脚本隐藏 Key——同源脚本在任意时刻都能调用
+ *  get() 或拦截 fetch。此处通过「闭包 + 非枚举属性 + 分页会话绑定」降低
+ *  XSS / 误操作泄露面，真正的密钥隔离仍须依赖后端代理（见 ai-client.js 的
+ *  server.py 透传模式说明）。
+ * ============================================================
+ */
+(function () {
+  'use strict';
+
+  if (window.BioQuestKeyStore) return; // 幂等，避免重复装载覆盖
+
+  var _key = '';                                  // 页面内存中的 Key
+  var _SESSION_KEY = 'bioquest_ai_key_session';   // 会话内持久化槽（sessionStorage）
+  var _REMEMBER_FLAG = 'bioquest_ai_key_remember';// 「会话内记住」偏好（非敏感）
+  var _LEGACY_CFG = 'bioquest_ai_key_config';     // 旧版 localStorage 明文槽
+
+  function _isValid(k) {
+    return typeof k === 'string' && k.length >= 8;
+  }
+
+  function _readSession() {
+    try { return sessionStorage.getItem(_SESSION_KEY) || ''; } catch (e) { return ''; }
+  }
+
+  function _writeSession(k) {
+    try {
+      if (k) sessionStorage.setItem(_SESSION_KEY, k);
+      else sessionStorage.removeItem(_SESSION_KEY);
+    } catch (e) {
+      // Safari 隐私模式等场景写入 sessionStorage 可能抛异常：忽略，退化为页面内存
+    }
+  }
+
+  // 旧版迁移：localStorage 残留明文 Key → 搬入内存并立即擦除
+  function _migrateLegacy() {
+    try {
+      var raw = localStorage.getItem(_LEGACY_CFG);
+      if (!raw) return '';
+      var cfg = JSON.parse(raw);
+      if (cfg && _isValid(cfg.apiKey)) {
+        var k = cfg.apiKey;
+        cfg.apiKey = '';
+        localStorage.setItem(_LEGACY_CFG, JSON.stringify(cfg));
+        return k;
+      }
+    } catch (e) { /* 损坏数据则忽略 */ }
+    return '';
+  }
+
+  var store = {
+    get: function () {
+      if (_key) return _key;                       // 优先内存
+      var s = _readSession();                      // 会话内记住模式下的恢复
+      if (_isValid(s)) { _key = s; return s; }
+      var legacy = _migrateLegacy();               // 旧版残量迁移
+      if (legacy) { _key = legacy; return legacy; }
+      return '';
+    },
+    set: function (k, remember) {
+      _key = (typeof k === 'string') ? k : '';
+      var r = !!remember;
+      // 仅当用户显式选择「会话内记住」时才写入 sessionStorage，否则清理
+      _writeSession(r && _key ? _key : '');
+      try {
+        if (r) localStorage.setItem(_REMEMBER_FLAG, '1');
+        else localStorage.removeItem(_REMEMBER_FLAG);
+      } catch (e) { /* 忽略偏好写入失败 */ }
+    },
+    clear: function () {
+      _key = '';
+      try { sessionStorage.removeItem(_SESSION_KEY); } catch (e) {}
+    },
+    isRemember: function () {
+      try { return localStorage.getItem(_REMEMBER_FLAG) === '1'; } catch (e) { return false; }
+    }
+  };
+
+  // 以「不可枚举」方式暴露，避免被 Object.keys(window) 等常规枚举直接发现
+  try {
+    Object.defineProperty(window, 'BioQuestKeyStore', { value: store, enumerable: false, configurable: true, writable: false });
+  } catch (e) {
+    window.BioQuestKeyStore = store;
+  }
+})();

--- a/js/app.js
+++ b/js/app.js
@@ -375,6 +375,48 @@ function _privacySection(title, items) {
 }
 
 /**
+ * 首次访问隐私政策提示（P1-19）。
+ * 一次性、可关闭；仅用内联样式 + textContent/按钮，无内联脚本（符合 CSP）。
+ * 关键约束：任何分支都不抛异常、不依赖 DOM 状态，绝不影响 initApp 后续执行
+ * （initApp 在 DOMContentLoaded 直接触发，无 try/catch 兜底）。
+ */
+function _maybeShowPrivacyNotice() {
+  try {
+    var seen = false;
+    try { seen = localStorage.getItem('bioquest_privacy_notice_seen') === '1'; } catch (e) {}
+    if (seen || typeof document === 'undefined' || !document.body) return;
+
+    var el = document.createElement('div');
+    el.id = 'privacy-notice';
+    el.setAttribute('role', 'alert');
+    el.style.cssText = 'position:fixed;left:12px;right:12px;bottom:12px;z-index:2147483000;' +
+      'display:flex;flex-wrap:wrap;align-items:center;gap:12px;padding:14px 16px;border-radius:12px;' +
+      'background:#ffffff;border:1px solid #ece8e1;box-shadow:0 6px 24px rgba(0,0,0,0.12);' +
+      'font-family:var(--font-sans, sans-serif);font-size:0.85rem;color:#2c3e30;line-height:1.5;max-width:640px;margin:0 auto;';
+    var txt = document.createElement('span');
+    txt.style.cssText = 'flex:1;min-width:220px;';
+    txt.textContent = '我们重视你的数据隐私：学习数据默认仅保存在本地，可随时导出或清除。';
+    var link = document.createElement('a');
+    link.href = '#/privacy';
+    link.textContent = '查看隐私政策';
+    link.style.cssText = 'color:#3a6b4a;font-weight:600;white-space:nowrap;text-decoration:none;';
+    var closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.textContent = '我知道了';
+    closeBtn.style.cssText = 'border:1px solid #3a6b4a;background:#3a6b4a;color:#fff;border-radius:8px;padding:6px 14px;font-size:0.82rem;cursor:pointer;white-space:nowrap;';
+    closeBtn.addEventListener('click', function () {
+      try { localStorage.setItem('bioquest_privacy_notice_seen', '1'); } catch (e) {}
+      if (el.parentNode) el.parentNode.removeChild(el);
+    });
+
+    el.appendChild(txt);
+    el.appendChild(link);
+    el.appendChild(closeBtn);
+    document.body.appendChild(el);
+  } catch (e) { /* 提示失败绝不能影响应用启动 */ }
+}
+
+/**
  * 获取当前 hash 对应的路由路径
  * @returns {string} 路由路径，如 '/', '/practice', '/exam'
  */

--- a/js/app.js
+++ b/js/app.js
@@ -121,6 +121,10 @@ const Routes = {
     module: 'user',
     auth: true
   },
+  '/privacy': {
+    title: '隐私政策',
+    module: 'privacy'
+  },
   '/search': {
     title: '搜索',
     render: 'renderSearchPage',
@@ -293,6 +297,82 @@ const Routes = {
     module: 'daily-billion'
   },
 };
+
+/**
+ * 隐私政策页（静态内容，P1-19）
+ * 仅内联样式（CSP style-src 允许 'unsafe-inline'），不含内联脚本，避免引入 XSS 面。
+ */
+function renderPrivacyPage(target) {
+  if (!target) return;
+  var s = {
+    bg: '#f7f5f0',
+    card: '#ffffff',
+    border: '#ece8e1',
+    text: '#2c3840',
+    muted: '#8a8a8a',
+    sage: '#3a6b4a',
+    accent: '#1a3a2a'
+  };
+  target.innerHTML =
+  '<div style="max-width:860px;margin:0 auto;padding:40px 20px 64px;font-family:var(--font-sans,\'Noto Sans SC\',sans-serif);color:' + s.text + ';line-height:1.8;">' +
+    '<a href="#/" style="display:inline-flex;align-items:center;gap:6px;color:' + s.sage + ';text-decoration:none;font-size:0.88rem;margin-bottom:20px;">← 返回首页</a>' +
+    '<div style="background:' + s.card + ';border:1px solid ' + s.border + ';border-radius:16px;padding:36px 40px 44px;box-shadow:0 4px 20px rgba(0,0,0,0.04);">' +
+      '<h1 style="font-family:var(--font-serif,\'Noto Serif SC\',serif);font-size:1.7rem;color:' + s.accent + ';margin:0 0 6px;">隐私政策</h1>' +
+      '<p style="color:' + s.muted + ';font-size:0.82rem;margin:0 0 26px;">更新日期：2026-08-19 · 适用于 BioQuest（生物竞赛学习平台）</p>' +
+      _privacySection('一、我们收集哪些数据', [
+        '账户信息：你在登录/注册时提供的姓名、邮箱（例如通过 Supabase 账号系统）。',
+        '学习数据：练习作答、错题、收藏、统计、习惯打卡、徽章与学习进度等，默认仅保存在你的浏览器本地（localStorage／IndexedDB）。',
+        '设备标识：用于本地数据关联的匿名设备标识（bioquest.xxx 下）。',
+        '日志：浏览器控制台与运行错误日志，仅用于排障，不含可直读的敏感凭据。'
+      ]) +
+      _privacySection('二、数据如何使用', [
+        '用于个性化学习：错题复盘、学情分析、成绩画像、复习排程（FSRS/IRT 算法）。',
+        '用于功能交互：社区、排行榜、教师协同视图、AI 助手（见第五条）。',
+        '不会在未经你同意的情况下用于广告画像或出售给第三方。'
+      ]) +
+      _privacySection('三、数据存储与安全', [
+        '默认本地优先：学习数据存于你的浏览器本地存储；你可在「用户中心 → 数据管理」导出备份或一键清除。',
+        '云端数据（如已登录账号、反馈、社区内容、AI 额度的服务端部分）通过 Supabase 存储与传输。',
+        'API Key 保护：AI 接口 Key 仅保存在当前页面内存（可选「会话内记住」写入 sessionStorage，关闭标签页即清除），不会持久化到你浏览器的 localStorage 或磁盘，也不会在控制台之外以明文全局属性暴露。',
+        '传输加密：外发请求走 HTTPS，第三方 AI 服务商在请求中有独立的服务条款与隐私政策。'
+      ]) +
+      _privacySection('四、Cookie 与本地存储', [
+        '本平台主要依赖浏览器 Web Storage（localStorage / sessionStorage / IndexedDB）存储功能数据，而非传统 Cookie。',
+        '第三方服务（Supabase、AI 服务商、jsDelivr CDN 等）可能按其自身政策使用 Cookie／本地存储，请查阅各自隐私政策。',
+        '你可随时在浏览器设置中清除站点本地数据；清除后学习数据将不可恢复（建议先导出备份）。'
+      ]) +
+      _privacySection('五、AI 功能与第三方处理', [
+        'AI 助手（导师、诊断、文档问答等）会将你的提问与相关上下文发送到所选 AI 服务商（如 DeepSeek、智谱、通义千问、Kimi、NVIDIA、硅基流动）的接口处理。',
+        '若你使用自定义 API Key，请求由你的前端携带你的 Key 直连服务商；请勿将涉及他人敏感信息的文本提交给 AI 功能。',
+        'AI 调用受每日次数限制，用于防止滥用。'
+      ]) +
+      _privacySection('六、你的权利', [
+        '访问权：在「用户中心」查看个人与学习数据。',
+        '导出权：在「用户中心 → 数据管理 → 导出我的数据」获取可读明文 JSON。',
+        '删除权：在「用户中心 → 数据管理 → 清除所有数据」删除本地全部业务数据；账号相关数据可在登录状态下申请。',
+        '撤回同意与投诉：可通过下方邮箱联系我们对数据处理行为提出异议。'
+      ]) +
+      _privacySection('七、未成年人保护', [
+        '本平台面向生物学科学习，若你为未成年人，建议在监护人指导下使用，并由监护人知悉本政策后使用。'
+      ]) +
+      _privacySection('八、政策更新与联系', [
+        '我们会不时更新本政策，重大变更将在页面明显位置提示。',
+        '如有隐私相关问题，可通过邮箱联系作者：astrnox@163.com（或 QQ：3930523703）。'
+      ]) +
+      '<div style="margin-top:8px;padding-top:18px;border-top:1px solid ' + s.border + ';font-size:0.82rem;color:' + s.muted + ';">BioQuest · 本政策以最新页面版本为准。</div>' +
+    '</div>' +
+  '</div>';
+  try { if (typeof updatePageTitle === 'function') updatePageTitle('/privacy'); } catch (e) {}
+}
+
+// 生成"小节标题 + 列表"的静态 HTML（仅内联样式，无脚本）
+function _privacySection(title, items) {
+  var lis = items.map(function (it) {
+    return '<li style="margin:6px 0;padding-left:2px;">' + String(it).replace(/&/g, '&amp;').replace(/</g, '&lt;') + '</li>';
+  }).join('');
+  return '<h2 style="font-family:var(--font-serif,\'Noto Serif SC\',serif);font-size:1.12rem;color:' + '#1a3a2a' + ';margin:26px 0 10px;">' + title + '</h2>' +
+    '<ul style="margin:0;padding-left:20px;font-size:0.9rem;color:#2c3840;">' + lis + '</ul>';
+}
 
 /**
  * 获取当前 hash 对应的路由路径
@@ -1938,6 +2018,9 @@ function doRouteRender(route, target) {
         break;
       case '/user':
         _safeInit('initUser', route, target);
+        break;
+      case '/privacy':
+        renderPrivacyPage(target);
         break;
       case '/search':
         renderSearchPage();
@@ -4963,6 +5046,9 @@ function initApp() {
   }
 
   restoreSettings();
+
+  // P1-19：首次访问时展示隐私政策提示（一次性，可关闭；无内联脚本）
+  _maybeShowPrivacyNotice();
 
   // 异步初始化 Supabase — 不阻塞页面首次渲染
   // 使用 requestIdleCallback 在空闲时初始化，确保首屏交互优先

--- a/js/integrations/data-store.js
+++ b/js/integrations/data-store.js
@@ -266,6 +266,26 @@
   }
 
   /**
+   * 清空整库（P1-17 GDPR/个保法删除权：连同 IndexedDB 用户数据一并删除，而非仅清 Web Storage）。
+   * 会先关闭当前 Dexie 连接，再调用 indexedDB.deleteDatabase 删除整个 bioquest-store 数据库。
+   * 若其他标签页仍持有连接（onblocked），尽力而为：resolve(false) 但不抛出。
+   * @returns {Promise<boolean>} 是否删除成功
+   */
+  function clearAll() {
+    try {
+      if (_db) { try { _db.close(); } catch (e) {} _db = null; }
+    } catch (e) {}
+    return new Promise(function (resolve) {
+      if (typeof indexedDB !== 'object' || !indexedDB) { resolve(false); return; }
+      var req;
+      try { req = indexedDB.deleteDatabase(DB_NAME); } catch (e) { resolve(false); return; }
+      req.onsuccess = function () { resolve(true); };
+      req.onerror = function () { resolve(false); };
+      req.onblocked = function () { resolve(false); }; // 其他标签页仍打开，尽力而为
+    });
+  }
+
+  /**
    * 计数
    */
   function count(table) {
@@ -393,6 +413,7 @@
     putRecord: putRecord,
     deleteRecord: deleteRecord,
     clearTable: clearTable,
+    clearAll: clearAll,
     count: count,
     queryByIndex: queryByIndex,
     addReview: addReview,

--- a/js/storage.js
+++ b/js/storage.js
@@ -41,9 +41,125 @@ function safeSetJSON(key, value) {
     localStorage.setItem(key, JSON.stringify(value));
     return true;
   } catch (e) {
+    var isQuota = !!(e && (e.name === 'QuotaExceededError' || e.code === 22 ||
+      String(e).toLowerCase().indexOf('quota') !== -1));
+    // P1-15：配额超限时先清理可重建的缓存类键再重试一次，避免关键数据静默丢失
+    if (isQuota && _evictCacheOnce() > 0) {
+      try {
+        localStorage.setItem(key, JSON.stringify(value));
+        return true;
+      } catch (e2) {
+        console.warn('[BioQuest Storage] 写入 ' + key + ' 失败（清理缓存后配额仍不足）:', e2.message);
+        return false;
+      }
+    }
+    if (isQuota) {
+      var usage = getStorageUsage();
+      if (usage.percent > 80 && !_quotaWarnFired) {
+        _quotaWarnFired = true;
+        console.warn('[BioQuest Storage] localStorage 已用约 ' + usage.percent.toFixed(0) + '%，接近配额，可能发生数据写入失败。建议导出备份并清理缓存数据。');
+      }
+      return false;
+    }
     console.warn('[BioQuest Storage] 写入 ' + key + ' 失败:', e.message);
     return false;
   }
+}
+
+var _quotaWarnFired = false;
+
+/**
+ * 估算 localStorage 已用字节数与占比（约 5MB 上限），供配额监控（P1-15）。
+ * @returns {{bytes:number, limit:number, percent:number}}
+ */
+function getStorageUsage() {
+  var bytes = 0;
+  try {
+    for (var i = 0; i < localStorage.length; i++) {
+      var k = localStorage.key(i);
+      var v = localStorage.getItem(k);
+      bytes += (k ? k.length : 0) + (v ? (v.length * 1) : 0); // 每个字符约 1 字节估算
+    }
+  } catch (e) {}
+  var limit = 5 * 1024 * 1024; // 约 5MB
+  return { bytes: bytes, limit: limit, percent: Math.min(100, bytes / limit * 100) };
+}
+
+/**
+ * 清除可重建的缓存类键（题面缓存/横幅/预览等），用于配额超限时的保守回收。
+ * @returns {number} 实际删除的键数量
+ */
+function _evictCacheOnce() {
+  var removed = 0;
+  try {
+    for (var i = localStorage.length - 1; i >= 0; i--) {
+      var k = localStorage.key(i);
+      if (k && (k.indexOf('cache') !== -1 || k.indexOf('banner') !== -1 || k.indexOf('preview') !== -1)) {
+        try { localStorage.removeItem(k); removed++; } catch (e) {}
+      }
+    }
+  } catch (e) {}
+  return removed;
+}
+
+/**
+ * 清除全部业务数据（P1-17 GDPR/个保法：删除所有本地数据）。
+ *   - Web Storage：清 bioquest_* 前缀的 localStorage 与 sessionStorage 键，
+ *     保留 Supabase 账号会话 token（sb-*）以维持登录；
+ *   - IndexedDB：删除 bioquest-store（Dexie 用户数据：cards/reviews/wrongbook/sessions/settings）
+ *     与 BioQuestCache（可重建的模块缓存 DB）。
+ * 由于 IndexedDB 删除为异步，本函数返回 Promise<boolean[]>；调用方可 .then 感知结果。
+ */
+function clearAllLocalData() {
+  return new Promise(function (resolve) {
+    // 1) Web Storage
+    try {
+      for (var i = localStorage.length - 1; i >= 0; i--) {
+        var k = localStorage.key(i);
+        if (k && k.indexOf('bioquest_') === 0) localStorage.removeItem(k);
+      }
+    } catch (e) {}
+    try {
+      for (var j = sessionStorage.length - 1; j >= 0; j--) {
+        var sk = sessionStorage.key(j);
+        if (sk && sk.indexOf('bioquest_') === 0) sessionStorage.removeItem(sk);
+      }
+    } catch (e) {}
+
+    // 2) IndexedDB：优先走 DataStore.clearAll()（会先关闭 Dexie 连接再删库），
+    //    覆盖 bioquest-store 用户数据库；BioQuestCache 为可重建模块缓存，一并删除。
+    var idbCalls = [];
+    if (typeof window.DataStore === 'object' && typeof window.DataStore.clearAll === 'function') {
+      idbCalls.push(window.DataStore.clearAll());
+    } else {
+      idbCalls.push(_deleteIndexedDb('bioquest-store'));
+    }
+    idbCalls.push(_deleteIndexedDb('BioQuestCache'));
+
+    Promise.all(idbCalls).then(function (results) {
+      if (results.join('').indexOf('false') !== -1) {
+        console.warn('[BioQuest Storage] 部分 IndexedDB 数据库删除未完成（可能因其他标签页仍打开）。建议关闭其他标签页后重试。');
+      }
+      resolve(results);
+    }, function () {
+      resolve([]);
+    });
+  });
+}
+
+/**
+ * 直接调用 indexedDB.deleteDatabase（尽力而为，异步）。
+ * @returns {Promise<boolean>}
+ */
+function _deleteIndexedDb(name) {
+  return new Promise(function (resolve) {
+    if (typeof indexedDB !== 'object' || !indexedDB) { resolve(false); return; }
+    var req;
+    try { req = indexedDB.deleteDatabase(name); } catch (e) { resolve(false); return; }
+    req.onsuccess = function () { resolve(true); };
+    req.onerror = function () { resolve(false); };
+    req.onblocked = function () { resolve(false); };
+  });
 }
 
 /**

--- a/js/user.js
+++ b/js/user.js
@@ -1113,6 +1113,13 @@ function renderSettingsPanel(container) {
           <input type="text" id="aiModelInput" placeholder="留空使用服务商默认推荐模型" value="${escapeHtml(apiKeyConfig.model || '')}" style="width:100%;margin-top:6px;padding:10px 12px;border:1px solid var(--border-light,#e3e0d8);border-radius:10px;font-size:0.84rem;background:var(--surface-primary,#fff);color:var(--text-primary,#1a1a1a);outline:none;">
         </div>
 
+        <div>
+          <label style="display:flex;align-items:center;gap:8px;font-size:0.8rem;color:var(--text-secondary,#4a4a4a);cursor:pointer;">
+            <input type="checkbox" id="aiKeyRememberCb" ${apiKeyConfig.remember ? 'checked' : ''} style="accent-color:var(--color-sage,#5a7d5c);width:16px;height:16px;">
+            <span>会话内记住 Key（刷新不丢失，关闭标签页自动清除）</span>
+          </label>
+        </div>
+
         <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:4px;">
           <button class="btn btn-sm btn-primary" id="aiKeySaveBtn">保存</button>
           <button class="btn btn-sm btn-secondary" id="aiKeyTestBtn">测试连接</button>
@@ -1153,7 +1160,7 @@ function renderSettingsPanel(container) {
             <p style="margin:0 0 8px;">访问 <a href="https://cloud.siliconflow.cn" target="_blank" style="color:var(--color-amber,#c4956a);">cloud.siliconflow.cn</a> → 注册 → 「API 密钥」。新用户送 14 元额度，Qwen2.5-7B 等小模型永久免费。模型填 <code style="background:rgba(0,0,0,0.05);padding:1px 5px;border-radius:3px;">Qwen/Qwen2.5-7B-Instruct</code></p>
 
             <p style="margin:10px 0 4px;padding-top:8px;border-top:1px dashed var(--border-light,#ece8e1);"><strong>🔒 隐私说明</strong></p>
-            <p style="margin:0;">API Key 仅保存在你本机浏览器 localStorage，不会上传服务器，也不会与他人共享。每次 AI 调用从前端直接转发到对应服务商。</p>
+            <p style="margin:0;">API Key 仅保存在当前页面的内存中；若勾选「会话内记住」，会额外存入本标签页的 sessionStorage（关闭标签页即自动清除）。Key 不会上传服务器，也不会持久化到你浏览器的 localStorage 或磁盘，关闭浏览器后长期不留存。</p>
 
             <p style="margin:10px 0 4px;"><strong>⚡ 用量限制</strong></p>
             <p style="margin:0;">为避免滥用，每个用户每日限 ${_AI_DAILY_LIMIT} 次 AI 调用，0:00 自动重置。自定义 Key 用户同样受此限制。</p>
@@ -1199,42 +1206,49 @@ var _AI_DAILY_LIMIT = 100; // 每用户每日限 100 次 AI 调用
 var _AI_KEY_STORAGE = 'bioquest_ai_key_config';
 var _AI_USAGE_STORAGE = 'bioquest_ai_usage';
 
-// 安全：API Key 仅存页面内存（window 全局对象），不落 localStorage
-// 原因 1：XSS 无法直接从 localStorage 一锅端；2：保证 user.js 与 ai-client.js 在刷新前能共享同一个 Key
-// 刷新后需重新输入 Key（符合"本地存储模式"说明）
-// 注意：使用 window 全局而不是模块私有变量，是为了让 ai-client.js 也能读到
-var _AI_MEM_KEY = '__bioquest_ai_key_memory__';
+// 安全：API Key 存储统一委托 window.BioQuestKeyStore（闭包化单例，P1-3 修复）。
+// - 页面内存：默认，刷新后需重新输入 Key；
+// - 会话内记住（用户显式勾选）：额外写入 sessionStorage，同标签页刷新可恢复，关闭标签页即清除；
+// - 绝不写入 localStorage，避免明文长留存磁盘；也不再使用 window 全局明文属性
+//   window.__bioquest_ai_key_memory__（该属性已由 ai-key-store.js 接管并废弃）。
+
 function _getMemKey() {
   try {
-    if (typeof window[_AI_MEM_KEY] === 'string') return window[_AI_MEM_KEY];
+    if (window.BioQuestKeyStore && typeof window.BioQuestKeyStore.get === 'function') {
+      return window.BioQuestKeyStore.get() || '';
+    }
   } catch (e) {}
   return '';
 }
-function _setMemKey(k) {
-  try { window[_AI_MEM_KEY] = String(k || ''); } catch (e) {}
+
+function _setMemKey(k, remember) {
+  try {
+    if (window.BioQuestKeyStore && typeof window.BioQuestKeyStore.set === 'function') {
+      window.BioQuestKeyStore.set(k, remember);
+    }
+  } catch (e) {}
 }
 
 function _loadApiKeyConfig() {
-  var cfg = { provider: 'deepseek', apiKey: '', model: '' };
+  var cfg = { provider: 'deepseek', apiKey: '', model: '', remember: false };
   try {
     var raw = localStorage.getItem(_AI_KEY_STORAGE);
     if (raw) {
       var stored = JSON.parse(raw);
       cfg.provider = stored.provider || cfg.provider;
       cfg.model = stored.model || '';
-      // 旧版本迁移：localStorage 中残留的明文 Key 移到内存并立即擦除
-      if (stored.apiKey) {
-        _setMemKey(stored.apiKey);
-        _saveApiKeyConfig({ provider: cfg.provider, apiKey: stored.apiKey, model: cfg.model });
-      }
     }
   } catch (e) {}
+  // 旧版 localStorage 明文 Key 的迁移由 BioQuestKeyStore.get() 内部完成并擦除
   cfg.apiKey = _getMemKey();
+  cfg.remember = !!(window.BioQuestKeyStore && window.BioQuestKeyStore.isRemember &&
+    window.BioQuestKeyStore.isRemember());
   return cfg;
 }
 
-function _saveApiKeyConfig(cfg) {
-  _setMemKey((cfg && cfg.apiKey) || '');
+function _saveApiKeyConfig(cfg, remember) {
+  // API Key 一律经闭包单例保存（可选「会话内记住」），绝不落 localStorage
+  _setMemKey((cfg && cfg.apiKey) || '', !!remember);
   try {
     localStorage.setItem(_AI_KEY_STORAGE, JSON.stringify({
       provider: (cfg && cfg.provider) || 'deepseek',
@@ -1320,6 +1334,12 @@ function _bindApiKeySettings() {
     });
   }
 
+  // 读取「会话内记住」勾选项
+  function _rememberChecked() {
+    var cb = document.getElementById('aiKeyRememberCb');
+    return !!(cb && cb.checked);
+  }
+
   var saveBtn = document.getElementById('aiKeySaveBtn');
   if (saveBtn) {
     saveBtn.addEventListener('click', function() {
@@ -1338,11 +1358,15 @@ function _bindApiKeySettings() {
         if (typeof showToast === 'function') showToast('请输入 API Key');
         return;
       }
-      _saveApiKeyConfig(cfg);
+      _saveApiKeyConfig(cfg, _rememberChecked());
       // 恢复遮罩显示
       keyInput.value = cfg.apiKey.length > 4 ? '****' + cfg.apiKey.slice(-4) : '****';
       keyInput.type = 'password';
-      if (typeof showToast === 'function') showToast('已保存（Key 仅存内存，刷新页面后需重新输入）');
+      if (typeof showToast === 'function') {
+        showToast(_rememberChecked()
+          ? '已保存（会话内记住：刷新不丢失，关闭标签页自动清除）'
+          : '已保存（Key 仅存当前页面内存，刷新页面后需重新输入）');
+      }
     });
   }
 
@@ -1354,7 +1378,10 @@ function _bindApiKeySettings() {
   var clearBtn = document.getElementById('aiKeyClearBtn');
   if (clearBtn) {
     clearBtn.addEventListener('click', function() {
-      _saveApiKeyConfig({ provider: 'deepseek', apiKey: '', model: '' });
+      var cb = document.getElementById('aiKeyRememberCb');
+      // 清除 Key 的同时复位「会话内记住」偏好（remember=false 会一并清除 session 中的 Key 与偏好标记）
+      _saveApiKeyConfig({ provider: 'deepseek', apiKey: '', model: '' }, false);
+      if (cb) cb.checked = false;
       keyInput.value = '';
       document.getElementById('aiModelInput').value = '';
       document.getElementById('aiProviderSelect').value = 'deepseek';
@@ -1367,7 +1394,7 @@ function _testAiKeyConnection() {
   var resultEl = document.getElementById('aiKeyTestResult');
   if (!resultEl) return;
   var inputVal = document.getElementById('aiApiKeyInput').value.trim();
-  // 如果输入框是遮罩值，从 localStorage 读取真实 Key
+  // 如果输入框是遮罩值，从内存单例读取真实 Key（不再触达已废弃的明文全局属性）
   if (inputVal.indexOf('****') !== -1) {
     var existingCfg = _loadApiKeyConfig();
     inputVal = existingCfg.apiKey || '';
@@ -1406,8 +1433,9 @@ function _testAiKeyConnection() {
     if (resp.ok) {
       resultEl.textContent = '✓ 连接成功！模型 ' + model + ' 可用';
       resultEl.style.color = 'var(--color-sage,#3a6b4a)';
-      // 保存配置
-      _saveApiKeyConfig(cfg);
+      // 保存配置（携带「会话内记住」偏好）
+      _saveApiKeyConfig(cfg, document.getElementById('aiKeyRememberCb')
+        ? document.getElementById('aiKeyRememberCb').checked : false);
     } else {
       return resp.text().then(function(txt) {
         var msg = '✗ 连接失败（HTTP ' + resp.status + '）';
@@ -1770,10 +1798,18 @@ function renderDataManagement(container) {
       <div class="user-data-actions">
         <div class="user-data-action">
           <div class="user-data-action-info">
-            <div class="user-data-action-label">导出学习数据</div>
-            <div class="user-data-action-desc">将所有学习记录、收藏、错题导出为 JSON 文件</div>
+            <div class="user-data-action-label">导出加密备份</div>
+            <div class="user-data-action-desc">一键导出加密备份文件 (.bqb)，用于数据迁移与灾难还原（需本机解密密钥）</div>
           </div>
-          <button class="btn btn-sm btn-primary" id="userExportBtn">导出</button>
+          <button class="btn btn-sm btn-primary" id="userExportBtn">导出备份</button>
+        </div>
+
+        <div class="user-data-action">
+          <div class="user-data-action-info">
+            <div class="user-data-action-label">导出我的数据</div>
+            <div class="user-data-action-desc">输出可读的明文 JSON，包含学习记录、收藏、错题与统计，供自行查看与留存（GDPR/个保法数据可携权）</div>
+          </div>
+          <button class="btn btn-sm btn-secondary" id="userExportPlainBtn">导出明文</button>
         </div>
 
         <div class="user-data-action">
@@ -1799,7 +1835,16 @@ function renderDataManagement(container) {
   document.getElementById('userExportBtn').addEventListener('click', async () => {
     if (typeof exportData === 'function') {
       var result = await exportData();
-      showToast(result ? '数据已导出' : '数据导出失败');
+      showToast(result ? '加密备份已导出' : '数据导出失败');
+    }
+  });
+
+  document.getElementById('userExportPlainBtn').addEventListener('click', async () => {
+    if (typeof exportData === 'function') {
+      var result = await exportData({ encrypted: false });
+      showToast(result ? '明文数据已导出（我的数据 .json）' : '数据导出失败');
+    } else {
+      showToast('导出模块未就绪');
     }
   });
 
@@ -1831,21 +1876,33 @@ function renderDataManagement(container) {
     showConfirmDialog(
       '!',
       '确认清除所有数据？',
-      '此操作将删除所有学习记录、收藏、错题和统计数据，且不可恢复。建议先导出备份。',
+      '此操作将删除全部学习记录、收藏、错题、统计、习惯、AI 配置与本地缓存等所有 bioquest_* 数据，且不可恢复。建议先导出备份。',
       () => {
         try {
-          const keys = Object.values(
-            typeof KEYS !== 'undefined' ? KEYS : {
-              SETTINGS: 'bioquest_settings',
-              RECORDS: 'bioquest_records',
-              FAVORITES: 'bioquest_favorites',
-              WRONG_QUESTIONS: 'bioquest_wrong_questions',
-              STATS: 'bioquest_stats'
+          // 清除 Web Storage + IndexedDB 用户数据库（clearAllLocalData 现已一并删除 Dexie 数据，
+          // 如 cards/reviews/wrongbook/sessions/settings，以及可重建的 BioQuestCache 缓存）
+          var wipePromise;
+          if (typeof window.clearAllLocalData === 'function') {
+            wipePromise = window.clearAllLocalData();
+          } else {
+            // 兜底：仅清 Web Storage
+            for (var i = localStorage.length - 1; i >= 0; i--) {
+              var k = localStorage.key(i);
+              if (k && k.indexOf('bioquest_') === 0) localStorage.removeItem(k);
             }
-          );
-          keys.forEach((k) => localStorage.removeItem(k));
-          showToast('所有数据已清除');
-          refreshAllData();
+            wipePromise = Promise.resolve([]);
+          }
+          // 一并清除 AI Key 内存与会话内 Key
+          if (typeof window.BioQuestKeyStore === 'object' && window.BioQuestKeyStore.clear) {
+            try { window.BioQuestKeyStore.clear(); } catch (e) {}
+          }
+          wipePromise.then(function () {
+            showToast('所有数据已清除');
+            refreshAllData();
+          }, function () {
+            showToast('部分数据可能未完全清除（请关闭其他标签页后重试）');
+            refreshAllData();
+          });
         } catch (e) {
           showToast('清除失败: ' + e.message);
         }
@@ -1855,14 +1912,17 @@ function renderDataManagement(container) {
 }
 
 function showConfirmDialog(icon, title, text, onConfirm) {
-  var safeIcon = typeof escapeHtml === 'function' ? escapeHtml(icon) : String(icon).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  var esc = function (s) {
+    return typeof escapeHtml === 'function' ? escapeHtml(s) : String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  };
+  var safeIcon = esc(icon);
   const overlay = document.createElement('div');
   overlay.className = 'user-confirm-overlay';
   overlay.innerHTML = `
     <div class="user-confirm-dialog">
       <div class="user-confirm-icon">${safeIcon}</div>
-      <div class="user-confirm-title">${title}</div>
-      <div class="user-confirm-text">${text}</div>
+      <div class="user-confirm-title">${esc(title)}</div>
+      <div class="user-confirm-text">${esc(text)}</div>
       <div class="user-confirm-actions">
         <button class="btn btn-sm btn-secondary" id="confirmCancel">取消</button>
         <button class="btn btn-sm btn-danger" id="confirmOk">确认清除</button>


### PR DESCRIPTION
## 变更内容

本轮针对审计中若干最高优先级的 P1 项修复，覆盖四块：

### 1) AI API Key 安全存储（P1-3）
- 新增 `js/ai-key-store.js` 闭包单例 `BioQuestKeyStore`，Key 仅存于模块闭包内存，不再以 `window` 可枚举全局明文属性暴露（`__bioquest_ai_key_memory__` 已废弃）。
- 支持「会话内记住」（用户显式勾选）：额外写入 `sessionStorage`，同标签页刷新可恢复、关闭标签页自动清除，不落 `localStorage` 长期留存。
- 自动迁移旧版残留的 `localStorage` 明文 Key，迁移后立即擦除。
- `user.js` / `ai-client.js` 统一改走该单例读取；`loadConfig()` 不再返回 Key。

### 2) 数据导出 / 删除（P1-17，GDPR/个保法）
- 「用户中心 → 数据管理」拆分「导出加密备份」与「导出明文 JSON」，支持数据可携权。
- 「清除所有数据」扩展为**同时删除 IndexedDB 用户数据**（`bioquest-store` 下的 cards / reviews / wrongbook / sessions / settings）与可重建缓存库 `BioQuestCache`，而非仅清 Web Storage——修复原实现删不干净、学习数据仍残留本地的合规缺口。
- 清除时同步复位 AI Key 内存与会话内 Key。

### 3) localStorage 配额管理（P1-15）
- `safeSetJSON` 增加配额检测、可重建缓存自动回收并重试，避免关键数据静默写入失败；新增用量估算与接近配额警告。

### 4) 隐私政策（P1-19）
- 新增 `#/privacy` 路由与静态页面（收集 / 使用 / 存储安全 / Cookie / AI 第三方处理 / 用户权利 / 未成年人 / 联系），页脚加入口，首次访问一次性提示。
- 联系方式替换为代码库中真实作者信息，移除「占位」失效邮件。

## 为什么改
- 纯前端结构的 Key 明文暴露与「删除不彻底」违反 GDPR / 个保法的安全与删除权要求；配额超限会导致学习数据静默丢失；隐私政策缺失且含占位联系方式不满足合规披露。

## 影响
- 用户无感知升级；清除数据行为更彻底、更符合删除权预期。
- AI Key 在非「会话内记住」时仅存当前页面内存，刷新需重填（已如实提示）。

## 验证
- 全部改动文件通过 `node --check` 语法校验。
- 安全边界审查：全量 grep 确认无 `console.*` 记录 Key、无新增明文全局暴露点。

## 已知残余风险
纯前端无法真正向页面内脚本隐藏 Key（同源脚本理论上可调用 `get()` 或拦截 fetch）；真正的密钥隔离仍须后端代理透传。