### PR TITLE
fix: 修复全部 P1 级缺陷（安全/无障碍/PWA/测试门禁 13 项）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,9 @@ jobs:
           diff /tmp/shards-before.sha /tmp/shards-after.sha \
             || { echo "题库分片与生成器不一致：请运行 node scripts/generate-bio-shards.js 并提交结果"; exit 1; }
 
-      - name: 单元测试（IRT / FSRS）
+      - name: 单元测试（IRT / FSRS / 调度器 + 覆盖率门禁）
+        # #140/#141：--coverage 已并入 test:unit；低于 jest.config.cjs
+        # coverageThreshold 的任何指标都会使本步骤失败（防覆盖率回退）
         run: npm run test:unit
 
       - name: 烟雾测试（Wiki）

--- a/400.html
+++ b/400.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>400 - 请求无效 | BioQuest</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/401.html
+++ b/401.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>401 - 未授权访问 | BioQuest</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/403.html
+++ b/403.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>403 - 访问被拒绝 | BioQuest</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/404.html
+++ b/404.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>404 - 页面未找到 | BioQuest</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/500.html
+++ b/500.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>500 - 服务器错误 | BioQuest</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/502.html
+++ b/502.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>502 - 网关错误 | BioQuest</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/503.html
+++ b/503.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>503 - 服务不可用 | BioQuest</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/LICENSE
+++ b/LICENSE
@@ -1,281 +1,440 @@
 SPDX-License-Identifier: CC-BY-NC-SA-4.0
 
-Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License (CC BY-NC-SA 4.0)
+Attribution-NonCommercial-ShareAlike 4.0 International
 
-By exercising the Licensed Rights (defined below), You accept and agree to be bound
-by the terms and conditions of this Creative Commons Attribution-NonCommercial-
-ShareAlike 4.0 International Public License ("Public License"). To the extent this
-Public License may be interpreted as a contract, You are granted the Licensed Rights
-in consideration of Your acceptance of these terms and conditions, and the Licensor
-grants You such rights in consideration of benefits the Licensor receives from making
-the Licensed Material available under these terms and conditions.
+=======================================================================
 
-==============================================================================
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-NonCommercial-ShareAlike 4.0 International Public License
+("Public License"). To the extent this Public License may be
+interpreted as a contract, You are granted the Licensed Rights in
+consideration of Your acceptance of these terms and conditions, and the
+Licensor grants You such rights in consideration of benefits the
+Licensor receives from making the Licensed Material available under
+these terms and conditions.
+
+
 Section 1 -- Definitions.
-==============================================================================
 
-  a. Adapted Material means material subject to Copyright and Similar Rights that
-  is derived from or based upon the Licensed Material and in which the Licensed
-  Material is translated, altered, arranged, transformed, or otherwise modified
-  in a manner requiring permission under the Copyright and Similar Rights held by
-  the Licensor.
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
 
-  b. Adapter's License means the license You apply to Your Copyright and Similar
-  Rights in Your contributions to Adapted Material in accordance with the terms
-  and conditions of this Public License.
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
 
-  c. BY-NC-SA Compatible License means a license listed at creativecommons.org/
-  compatiblelicenses, approved by Creative Commons as essentially the equivalent
-  of this Public License.
+  c. BY-NC-SA Compatible License means a license listed at
+     creativecommons.org/compatiblelicenses, approved by Creative
+     Commons as essentially the equivalent of this Public License.
 
-  d. Copyright and Similar Rights means copyright and/or similar rights closely
-  related to copyright including, without limitation, performance, broadcast,
-  sound recording, and Sui Generis Database Rights, without regard to how the
-  rights are labeled or categorized.
+  d. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
 
-  e. Effective Technological Measures means those measures that, in the absence
-  of proper authority, may not be circumvented under laws fulfilling obligations
-  under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996,
-  and/or similar international agreements.
+  e. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
 
-  f. Exceptions and Limitations means fair use, fair dealing, and/or any other
-  exception or limitation to Copyright and Similar Rights that applies to Your
-  use of the Licensed Material.
+  f. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
 
-  g. License Elements means the license attributes listed in the name of a
-  Creative Commons Public License. The License Elements of this Public License
-  are Attribution, NonCommercial, and ShareAlike.
+  g. License Elements means the license attributes listed in the name
+     of a Creative Commons Public License. The License Elements of this
+     Public License are Attribution, NonCommercial, and ShareAlike.
 
-  h. Licensed Material means the artistic or literary work, database, or other
-  material to which the Licensor applied this Public License.
+  h. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
 
-  i. Licensed Rights means the rights granted to You subject to the terms and
-  conditions of this Public License, which are limited to all Copyright and
-  Similar Rights that apply to Your use of the Licensed Material and that the
-  Licensor has authority to license.
+  i. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
 
-  j. Licensor means the individual(s) or entity(ies) granting rights under this
-  Public License.
+  j. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
 
   k. NonCommercial means not primarily intended for or directed towards
-  commercial advantage or monetary compensation.
+     commercial advantage or monetary compensation. For purposes of
+     this Public License, the exchange of the Licensed Material for
+     other material subject to Copyright and Similar Rights by digital
+     file-sharing or similar means is NonCommercial provided there is
+     no payment of monetary compensation in connection with the
+     exchange.
 
-  l. Share means to provide material to the public by any means or process that
-  requires permission under the Licensed Rights, such as reproduction, public
-  display, public performance, distribution, dissemination, communication, or
-  importation, and to make material available to the public including in ways
-  that members of the public may access the material from a place and at a time
-  individually chosen by them.
+  l. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
 
-  m. Sui Generis Database Rights means rights other than copyright resulting
-  from Directive 96/9/EC of the European Parliament and of the Council of 11
-  March 1996 on the legal protection of databases, as amended and/or succeeded,
-  as well as other essentially equivalent rights anywhere in the world.
+  m. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
 
-  n. You means the individual or entity exercising the Licensed Rights under
-  this Public License.
+  n. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
 
-==============================================================================
+
 Section 2 -- Scope.
-==============================================================================
 
   a. License grant.
-    1. Subject to the terms and conditions of this Public License, the Licensor
-    hereby grants You a worldwide, royalty-free, non-sublicensable, non-
-    exclusive, irrevocable license to exercise the Licensed Rights in the
-    Licensed Material to:
-        A. reproduce and Share the Licensed Material, in whole or in part, for
-        NonCommercial purposes only; and
-        B. produce, reproduce, and Share Adapted Material for NonCommercial
-        purposes only.
-    2. Exceptions and Limitations. For the avoidance of doubt, where
-    Exceptions and Limitations apply to Your use, this Public License does not
-    apply, and You do not need to comply with its terms and conditions.
-    3. Term. The term of this Public License is specified in Section 6(a).
-    4. Media and formats; technical modifications allowed. The Licensor
-    authorizes You to exercise the Licensed Rights in all media and formats
-    whether now known or hereafter created, and to make technical modifications
-    necessary to do so.
-    5. Downstream recipients.
-        A. Offer from the Licensor -- Licensed Material. Every recipient of the
-        Licensed Material automatically receives an offer from the Licensor to
-        exercise the Licensed Rights under the terms and conditions of this
-        Public License.
-        B. Additional offer from the Licensor -- Adapted Material. Every
-        recipient of Adapted Material from You automatically receives an offer
-        from the Licensor to exercise the Licensed Rights in the Adapted
-        Material under the conditions of the Adapter's License You apply.
-        C. No downstream restrictions. You may not offer or impose any
-        additional or different terms or conditions on, or apply any Effective
-        Technological Measures to, the Licensed Material if doing so restricts
-        exercise of the Licensed Rights by any recipient of the Licensed
-        Material.
-    6. No endorsement. Nothing in this Public License constitutes or may be
-    construed as permission to assert or imply that You are, or that Your use
-    of the Licensed Material is, connected with, or sponsored, endorsed, or
-    granted official status by, the Licensor or others designated to receive
-    attribution as provided in Section 3(a)(1)(A)(i).
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part, for NonCommercial purposes only; and
+
+            b. produce, reproduce, and Share Adapted Material for
+               NonCommercial purposes only.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. Additional offer from the Licensor -- Adapted Material.
+               Every recipient of Adapted Material from You
+               automatically receives an offer from the Licensor to
+               exercise the Licensed Rights in the Adapted Material
+               under the conditions of the Adapter's License You apply.
+
+            c. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
 
   b. Other rights.
-    1. Moral rights, such as the right of integrity, are not licensed under
-    this Public License, nor are publicity, privacy, and/or other similar
-    personality rights; however, to the extent possible, the Licensor waives
-    and/or agrees not to assert any such rights held by the Licensor to the
-    limited extent necessary to allow You to exercise the Licensed Rights, but
-    not in any other way.
-    2. Patent and trademark rights are not licensed under this Public License.
-    3. To the fullest extent possible, the Licensor waives any right to collect
-    royalties from You for the exercise of the Licensed Rights, whether directly
-    or through a collecting society under any voluntary or waivable statutory
-    or compulsory licensing scheme.
 
-==============================================================================
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties, including when
+          the Licensed Material is used other than for NonCommercial
+          purposes.
+
+
 Section 3 -- License Conditions.
-==============================================================================
 
-Your exercise of the Licensed Rights is expressly made subject to the following
-conditions.
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
 
   a. Attribution.
-    1. If You Share the Licensed Material (including in modified form), You
-    must:
-        A. retain the following if it is supplied by the Licensor with the
-        Licensed Material:
-            i. identification of the creator(s) of the Licensed Material and
-            any others designated to receive attribution, in any reasonable
-            manner requested by the Licensor (including by pseudonym if
-            designated);
-            ii. a copyright notice;
-            iii. a notice that refers to this Public License;
-            iv. a notice that refers to the disclaimer of warranties;
-            v. a URI or hyperlink to the Licensed Material to the extent
-            reasonably practicable;
-        B. indicate if You modified the Licensed Material and retain an
-        indication of any previous modifications; and
-        C. indicate the Licensed Material is licensed under this Public
-        License, and include the text of, or the URI or hyperlink to, this
-        Public License.
-    2. You may satisfy the conditions in Section 3(a)(1) in any reasonable
-    manner based on the medium, means, and context in which You Share the
-    Licensed Material.
-    3. If requested by the Licensor, You must remove any of the information
-    required by Section 3(a)(1)(A) to the extent reasonably practicable.
 
-  b. ShareAlike. In addition to the conditions in Section 3(a), if You Share
-  Adapted Material You produce, the following conditions also apply.
-    1. The Adapter's License You apply must be a Creative Commons license with
-    the same License Elements, this version or later, or a BY-NC-SA Compatible
-    License.
-    2. You must include the text of, or the URI or hyperlink to, the Adapter's
-    License You apply. You may satisfy this condition in any reasonable manner
-    based on the medium, means, and context in which You Share Adapted Material.
-    3. You may not offer or impose any additional or different terms or
-    conditions on, or apply any Effective Technological Measures to, Adapted
-    Material that restrict exercise of the rights granted under the Adapter's
-    License You apply.
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
 
-  c. NonCommercial. In addition to the conditions in Section 3(a), if You
-  Share Adapted Material You produce, the following condition also applies.
-    1. You may not exercise the Licensed Rights for NonCommercial purposes
-    unless you do so for NonCommercial purposes only.
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
 
-==============================================================================
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+  b. ShareAlike.
+
+     In addition to the conditions in Section 3(a), if You Share
+     Adapted Material You produce, the following conditions also apply.
+
+       1. The Adapter's License You apply must be a Creative Commons
+          license with the same License Elements, this version or
+          later, or a BY-NC-SA Compatible License.
+
+       2. You must include the text of, or the URI or hyperlink to, the
+          Adapter's License You apply. You may satisfy this condition
+          in any reasonable manner based on the medium, means, and
+          context in which You Share Adapted Material.
+
+       3. You may not offer or impose any additional or different terms
+          or conditions on, or apply any Effective Technological
+          Measures to, Adapted Material that restrict exercise of the
+          rights granted under the Adapter's License You apply.
+
+
 Section 4 -- Sui Generis Database Rights.
-==============================================================================
 
-Where the Licensed Rights include Sui Generis Database Rights that apply to
-Your use of the Licensed Material:
-  a. for the avoidance of doubt, Section 2(a)(1) grants You the right to
-  extract, reuse, reproduce, and Share all or a substantial portion of the
-  contents of the database for NonCommercial purposes only;
-  b. if You include all or a substantial portion of the database contents in a
-  database in which You have Sui Generis Database Rights, then the database in
-  which You have Sui Generis Database Rights (but not its individual contents)
-  is Adapted Material, including for purposes of Section 3(b); and
-  c. You must comply with the conditions in Section 3(a) if You Share all or a
-  substantial portion of the contents of the database.
-For the avoidance of doubt, this Section 4 supplements and does not replace
-Your obligations under this Public License where the Licensed Rights include
-other Copyright and Similar Rights.
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
 
-==============================================================================
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database for NonCommercial purposes
+     only;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material,
+     including for purposes of Section 3(b); and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
 Section 5 -- Disclaimer of Warranties and Limitation of Liability.
-==============================================================================
 
-  a. Unless otherwise separately undertaken by the Licensor, to the extent
-  possible, the Licensor offers the Licensed Material as-is and as-available,
-  and makes no representations or warranties of any kind concerning the
-  Licensed Material, whether express, implied, statutory, or other.
-  b. To the fullest extent possible, in no event will the Licensor be liable
-  to You on any legal theory (including, without limitation, negligence) or
-  otherwise for any direct, special, indirect, incidental, consequential,
-  punitive, exemplary, or other losses, costs, expenses, or damages arising
-  out of this Public License or use of the Licensed Material.
-  c. The disclaimer of warranties and limitation of liability provided above
-  shall be interpreted in a manner that, to the extent possible, most closely
-  approximates an absolute disclaimer and waiver of all liability.
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
 
-==============================================================================
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
 Section 6 -- Term and Termination.
-==============================================================================
 
-  a. This Public License applies for the term of the Copyright and Similar
-  Rights licensed here. However, if You fail to comply with this Public
-  License, then Your rights under this Public License terminate automatically.
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
   b. Where Your right to use the Licensed Material has terminated under
-  Section 6(a), it reinstates:
-    1. automatically as of the date the violation is cured, provided it is
-    cured within 30 days of Your discovery of the violation; or
-    2. upon express reinstatement by the Licensor.
-  c. For the avoidance of doubt, this Section 6(b) does not affect any right
-  the Licensor may have to seek remedies for Your violations of this Public
-  License.
-  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
+     Section 6(a), it reinstates:
 
-==============================================================================
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
 Section 7 -- Other Terms and Conditions.
-==============================================================================
 
-  a. The Licensor shall be bound by any additional or different terms or
-  conditions communicated by You under Section 3(b)(3) or Section 3(c)(3).
-  b. Any arrangements, understandings, or agreements regarding the Licensed
-  Material not stated herein are separate from and independent of the terms
-  and conditions of this Public License.
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
 
-==============================================================================
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
 Section 8 -- Interpretation.
-==============================================================================
 
-  a. For the avoidance of doubt, this Public License does not, and shall not
-  be interpreted to, reduce, limit, restrict, or impose conditions on any use
-  of the Licensed Material that could lawfully be made without permission
-  under this Public License.
-  b. To the fullest extent possible, if any provision of this Public License is
-  deemed unenforceable, it shall be automatically reformed to the minimum
-  extent necessary to make it enforceable.
-  c. No term or condition of this Public License will be waived and no failure
-  to comply consented to unless expressly agreed to by the Licensor.
-  d. Nothing in this Public License constitutes or may be interpreted as a
-  limitation upon, or waiver of, any privileges and immunities that apply to
-  the Licensor or You, including from the legal processes of any jurisdiction
-  or authority.
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
 
-==============================================================================
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
 
-Creative Commons is not a party to its public licenses. Notwithstanding, Creative
-Commons may elect to apply one of its public licenses to material it publishes and
-in those instances will be considered the "Licensor." The text of the Creative
-Commons public licenses is dedicated to the public domain under the CC0 Public
-Domain Dedication. Except for the limited purpose of indicating that material is
-shared under a Creative Commons public license or as otherwise permitted by the
-Creative Commons policies published at creativecommons.org/policies, Creative
-Commons does not authorize the use of the trademark "Creative Commons" or any
-other trademark or logo of Creative Commons without its prior written consent
-including, without limitation, in connection with any unauthorized modifications
-to any of its public licenses or any other arrangements, understandings, or
-agreements concerning use of licensed material. For the avoidance of doubt, this
-paragraph does not form part of the public licenses.
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
 
 Creative Commons may be contacted at creativecommons.org.
 
-Full license text: https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,79 @@
+# 安全策略（Security Policy）
+
+> 对应审计 Issue #101 / #103：将本项目的安全架构与边界文档化，便于贡献者理解设计取舍。
+
+## 支持版本
+
+| 版本 | 支持状态 |
+| ---- | -------- |
+| main 分支最新提交 | ✅ 支持 |
+| 历史版本 / 旧 release | ❌ 不支持 |
+
+## 漏洞报告
+
+请勿通过公开 Issue 报告安全漏洞。请使用 GitHub 私有安全通告（Security → Report a vulnerability），
+或联系仓库维护者。收到报告后我们会尽快评估并修复。
+
+---
+
+## 架构总览
+
+BioQuest 是**纯前端静态应用 + Supabase（Auth / 数据库 / RLS）**架构：
+
+- 前端静态托管（如 GitHub Pages），无自建业务后端、无服务端会话；
+- 认证与数据全部直连 Supabase，写权限由服务端 **RLS（Row Level Security）强制**；
+- 浏览器端数据使用 localStorage / sessionStorage / IndexedDB，**不使用 Cookie**。
+
+## 无 Cookie 架构与 CSRF 免疫（#101）
+
+本平台**不设置、不读取任何 Cookie**（全代码库无 `document.cookie` 调用）：
+
+- 认证凭据为 Supabase JWT，通过 `Authorization` 请求头由 Supabase JS SDK 携带，
+  存于 localStorage（`sb-*` 前缀），**不会**由浏览器自动附带；
+- 所有状态变更请求必须显式附带 token，跨站页面无法伪造用户请求 → **天然免疫经典 CSRF**；
+- 该结论的前提：凭据不进 Cookie。若未来引入 Cookie（如服务端渲染），
+  必须同步引入 CSRF 防护（如 SameSite=Lax + CSRF token）并更新本文档。
+
+## 会话与认证（#103）
+
+- **登录/注册**：`js/supabase-client.js` 走 Supabase Auth（`signInWithPassword` / `signUp`），
+  密码经 HTTPS 传输、由 Supabase 服务端哈希存储，前端不落盘；
+- **会话持久化**：Supabase SDK `persistSession: true`，token 存 localStorage；
+  `autoRefreshToken: true` 自动续期；`restoreSession()` 恢复会话（带 5 秒超时保护）；
+- **登出清理**：`logoutUser()` / `forceLogout()` 分层清除 `sb-*` 会话、游客会话、
+  管理员状态等全部敏感键，保留学习数据；
+- **管理员会话加固**：admin 前端 token 存 sessionStorage，**5 分钟 TTL** 自动过期；
+  登录后二次校验 `profiles.user_group === 'admin'`，非 admin 立即登出；
+  真正的写权限始终由服务端 RLS 强制，伪造前端状态无法提权。
+
+## AI 服务商 API Key（BYOK）
+
+采用 BYOK（用户自带 Key）模式，`js/ai-key-store.js`：
+
+- Key 默认仅存**页面内存**（闭包单例，非枚举属性），刷新即失；
+- 仅当用户显式勾选「会话内记住」才写 sessionStorage（关闭标签页即清除）；
+- **绝不写 localStorage**；检测到旧版 localStorage 残留明文 Key 会自动搬入内存并擦除。
+
+## 内容安全策略（CSP）
+
+`index.html` 通过 meta CSP 收紧（`js/ai-client.js` 同样受 `connect-src` 约束）：
+
+- `script-src 'self'` + CDN 白名单，**无 `unsafe-inline` / `unsafe-eval`**
+  （内联脚本已外部化，`onclick` 改为事件委托）；
+- `object-src 'none'`、`base-uri 'self'`、`form-action 'self'`；
+- 外连域最小化：Supabase、jsDelivr/unpkg、题图（Wikimedia）、PhET、6 家 AI 服务商。
+
+## 数据完整性
+
+- 题库分片带 SHA-256 校验（`js/loader.js`），CDN 回退数据防篡改；
+- 本地备份采用 WebCrypto AES-GCM 加密（`js/storage.js`），密钥由密码 PBKDF 派生；
+- URL 参数经 `sanitizeUrlParam` 清洗（控制字符 / HTML 定界符过滤 + 长度上限）。
+
+## 已知风险面（如实披露）
+
+- **localStorage 持久会话的 XSS 风险面**：token 存 localStorage 意味着一旦发生 XSS 即可窃取会话。
+  缓解手段：严格 CSP、全站输出转义、无第三方脚本注入面。这是「无 Cookie + CSRF 免疫」
+  与「token 不受 XSS 影响」之间的显式取舍；
+- **游客模式密码哈希非加密安全**：游客可选密码使用加盐 FNV-1a（非加密哈希），
+  仅防明文泄漏，不防御离线暴力破解（代码注释已声明）。正式账号无此问题；
+- **纯前端权限门禁仅为 UX**：admin 前端校验只是 UI 门禁，安全边界完全依赖 Supabase RLS。

--- a/biology-history.html
+++ b/biology-history.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>生物学史 - BioQuest</title>
   <meta name="description" content="从林奈到 AlphaFold，回顾改变生物学的关键时刻。BioQuest 生物学史时间轴以滑动方式展现生命科学的重大里程碑。">
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/cards.html
+++ b/cards.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>知识卡片 - BioQuest</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/css/globals.css
+++ b/css/globals.css
@@ -482,6 +482,12 @@ body {
   transform: scale(0.97);
 }
 
+/* #122 通用按压反馈：所有原生按钮/角色按钮按压时统一缩放。
+   使用 :where() 零特异性，仅作兜底 —— 页面级 :active 规则一律优先生效。 */
+:where(button, input[type='button'], input[type='submit'], [role='button']):where(:active:not(:disabled)) {
+  transform: scale(0.97);
+}
+
 .btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;

--- a/data/knowledge-graph.json
+++ b/data/knowledge-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "3.0.0",
-  "updated_at": "2026-08-18",
+  "updated_at": "2026-08-23",
   "categories": [
     {
       "name": "细胞生物学",

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,7 +1,7 @@
 {
   "rev": 2,
-  "updated_at": "2026-08-18",
-  "git": "6b962d9e4380bd69ede8f6d00f48652ff971503d",
+  "updated_at": "2026-08-23",
+  "git": "2474788947397cac092969a3e9d200a59b113430",
   "repo": "astrnox/BioQuest",
   "total_questions": 10952,
   "topics": [
@@ -1140,6 +1140,6 @@
     "index/plant_biotech.json": "fe1dc07bd89e45c5e77c18805ee2d89c41a81b4dc6b0abae47333f0d5642d624",
     "bank/plant_biotech.json": "4b281ecd31c0d8371bc6bdcbc82a658bfc3ad0ef000d88f2c78b4249bfd05b70",
     "bioid-map.json": "d4097f73b9d6b66a6ec32cec97f92efb8f450c87fb5fb8ef182ac6235797b278",
-    "knowledge-graph.json": "a4bc0ba938cb6446035de3afd0e15e6d2592f75e138cd6537bcdb63e32eb6594"
+    "knowledge-graph.json": "17e6b4405adddc74da92cf17a7026b0a598532e6d88e112770263fb459490bb5"
   }
 }

--- a/ebook.html
+++ b/ebook.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="theme-color" content="#1a2f1d">
   <title>电子书 - BioQuest</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/index.html
+++ b/index.html
@@ -2,7 +2,8 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, viewport-fit=cover">
+  <!-- #126 无障碍：移除 maximum-scale/minimum-scale（不得阻止用户捏合缩放）；viewport-fit=cover 适配刘海屏安全区 -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="theme-color" content="#1a2f1d">
   <meta name="color-scheme" content="light dark">

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -2,6 +2,16 @@ module.exports = {
   testEnvironment: 'node',
   testMatch: ['**/tests/unit/**/*.test.js'],
   verbose: true,
-  collectCoverageFrom: ['js/irt-engine.js', 'js/fsrs-algorithm.js', 'js/fsrs-optimizer.js'],
-  coverageDirectory: 'coverage'
+  // #140/#141 覆盖率门禁：只统计「require 加载」的模块（Istanbul 可插桩）。
+  // irt-engine / fsrs-* 系列在测试中经 (0, eval)(SRC) 动态求值加载，
+  // Istanbul 无法插桩（恒报 0%），纳入统计反而使门禁失真，故不在此列。
+  collectCoverageFrom: ['js/ai-client.js', 'js/utils.js'],
+  coverageDirectory: 'coverage',
+  // #140/#141 覆盖率门禁：任一指标低于阈值即整体失败（CI 已启用 --coverage）。
+  // 阈值定在当前实测值下方留有余量：防止覆盖率回退，而非追求虚高。
+  coverageThreshold: {
+    global: { statements: 10, branches: 5, functions: 8, lines: 10 },
+    './js/ai-client.js': { statements: 15, branches: 7, functions: 20, lines: 18 },
+    './js/utils.js': { statements: 6, branches: 5, functions: 3, lines: 7 }
+  }
 };

--- a/js/a11y-utils.js
+++ b/js/a11y-utils.js
@@ -208,24 +208,11 @@
     setTimeout(function () { region.textContent = String(message); }, 50);
   }
 
-  /**
-   * 给动态内容容器添加 aria-live 属性（用于流式输出区域）
-   * @param {HTMLElement} el - 容器元素
-   * @param {string} [level='polite']
-   */
-  function makeLive(el, level) {
-    if (!el) return;
-    el.setAttribute('aria-live', level || 'polite');
-    el.setAttribute('aria-atomic', 'false');
-    if (!el.getAttribute('role')) el.setAttribute('role', 'log');
-  }
-
   // 暴露到全局
   window.BioQuestA11y = {
     trapFocus: trapFocus,
     createLiveRegion: createLiveRegion,
     announce: announce,
-    makeLive: makeLive,
     FOCUSABLE_SELECTOR: FOCUSABLE_SELECTOR
   };
 

--- a/js/ai-client.js
+++ b/js/ai-client.js
@@ -187,6 +187,120 @@
     });
   }
 
+  /* ============================================================
+   * Issue P1-16（#135）：AI 请求限流与去重
+   * ------------------------------------------------------------
+   * 1) 速率限制：相邻请求最小启动间隔（AI_MIN_INTERVAL_MS，默认
+   *    600ms ≈ 100 次/分钟），超出的请求自动排队而非直接拒绝；
+   * 2) 并发上限：同时在飞的 AI 请求最多 AI_MAX_CONCURRENT 个，
+   *    防止快速连点并发打爆配额；
+   * 3) 排队超时：等待超过 AI_QUEUE_TIMEOUT_MS 直接报错，不无限堆积；
+   * 4) 请求去重：同指纹（endpoint+body 哈希）的非流式请求在复用
+   *    窗口内共享同一 Promise，快速重复点击只发一次真实请求。
+   * 说明：流式请求（streamChat）因各调用方持有独立 onChunk 回调，
+   *    不做结果复用，但同样受速率限制与并发上限约束；
+   *    tutor/discussion 模块已有的"新请求 abort 旧请求"逻辑保持不变。
+   * ============================================================ */
+  var AI_MAX_CONCURRENT = 3;        // 同时在飞的 AI 请求上限
+  var AI_MIN_INTERVAL_MS = 600;     // 相邻请求最小启动间隔（滑动窗口节流）
+  var AI_QUEUE_TIMEOUT_MS = 15000;  // 排队等待上限（超时报错）
+  var AI_DEDUP_TTL_MS = 5000;       // 去重指纹复用窗口（请求发起后）
+  var AI_DEDUP_MAP_MAX = 64;        // 去重表容量上限（防内存无限增长）
+
+  var _aiQueue = [];                // 等待启动的请求队列
+  var _aiInFlight = 0;              // 在飞请求计数
+  var _aiLastStartAt = 0;           // 上一次请求启动时间戳
+  var _aiDedupMap = new Map();      // fingerprint -> { promise, ts }
+  var _aiDrainTimer = null;         // 节流排空定时器（去重）
+
+  function _hashString(s) {
+    var h = 5381;
+    for (var i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) & 0xffffffff;
+    return (h >>> 0).toString(36);
+  }
+
+  /** 请求指纹：endpoint + 请求体哈希（非流式去重用） */
+  function _requestFingerprint(url, bodyObj) {
+    var bodyStr = '';
+    try { bodyStr = JSON.stringify(bodyObj); } catch (e) {}
+    return url + '#' + _hashString(bodyStr);
+  }
+
+  /**
+   * P1-16：统一的 AI 请求调度入口（限流 + 并发上限 + 排队 + 去重）。
+   * @param {Function} starter 无参函数，启动真实请求并返回 Promise
+   * @param {string|null} fingerprint 请求指纹（非 null 时启用并发去重）
+   * @returns {Promise}
+   */
+  function _scheduleAiRequest(starter, fingerprint) {
+    // 去重命中：同指纹请求仍在复用窗口内 → 共享同一 Promise
+    if (fingerprint) {
+      var hit = _aiDedupMap.get(fingerprint);
+      if (hit && (Date.now() - hit.ts) < AI_DEDUP_TTL_MS) return hit.promise;
+    }
+
+    var promise = new Promise(function (resolve, reject) {
+      _aiQueue.push({ starter: starter, resolve: resolve, reject: reject, enqueuedAt: Date.now() });
+      _drainAiQueue();
+    });
+
+    if (fingerprint) {
+      var entry = { promise: promise, ts: Date.now() };
+      _aiDedupMap.set(fingerprint, entry);
+      // 容量控制：超限时清掉最旧的过期项
+      if (_aiDedupMap.size > AI_DEDUP_MAP_MAX) {
+        var cutoff = Date.now() - AI_DEDUP_TTL_MS;
+        _aiDedupMap.forEach(function (v, k) { if (v.ts < cutoff) _aiDedupMap.delete(k); });
+      }
+      // 共享的 promise 附加空 catch，避免无人处理拒绝时触发全局告警
+      promise.catch(function () {});
+    }
+    return promise;
+  }
+
+  function _drainAiQueue() {
+    while (_aiQueue.length > 0) {
+      if (_aiInFlight >= AI_MAX_CONCURRENT) return;
+      // 最小启动间隔（滑动窗口节流）：未到间隔则定时后重试
+      var wait = AI_MIN_INTERVAL_MS - (Date.now() - _aiLastStartAt);
+      if (wait > 0) {
+        if (!_aiDrainTimer) {
+          _aiDrainTimer = setTimeout(function () {
+            _aiDrainTimer = null;
+            _drainAiQueue();
+          }, wait + 5);
+        }
+        return;
+      }
+      var job = _aiQueue.shift();
+      // 排队超时：还没启动就超时 → 拒绝并继续处理后续任务
+      if (Date.now() - job.enqueuedAt > AI_QUEUE_TIMEOUT_MS) {
+        job.reject(new Error('AI 请求排队超时（当前请求过多），请稍后重试'));
+        continue;
+      }
+      _aiInFlight++;
+      _aiLastStartAt = Date.now();
+      Promise.resolve()
+        .then(job.starter)
+        .then(job.resolve, job.reject)
+        .then(function () {
+          _aiInFlight--;
+          _drainAiQueue();
+        });
+    }
+  }
+
+  /** P1-16：调度器状态（供诊断/测试） */
+  function _schedulerStats() {
+    return {
+      inFlight: _aiInFlight,
+      queued: _aiQueue.length,
+      dedupEntries: _aiDedupMap.size,
+      maxConcurrent: AI_MAX_CONCURRENT,
+      minIntervalMs: AI_MIN_INTERVAL_MS
+    };
+  }
+
   // 加载用户配置（与 user.js 共享 localStorage key）
   // 统一规则（P0-1/S-001 修复，BYOK）：
   //   1) 用户在「我的 → 设置」配置的 Key 保存在页面内存，通过 _getApiKey() 读取；
@@ -439,29 +553,33 @@
       body.subject_id = METASO_SUBJECT_ID;
     }
 
-    return fetchWithRetry(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': 'Bearer ' + _getApiKey(),
-        'Accept': 'text/event-stream'
-      },
-      body: JSON.stringify(body),
-      signal: opts.signal
-    }).then(function (resp) {
-      if (!resp.ok) {
-        return resp.text().then(function (txt) {
-          throw new Error(_extractApiError(resp.status, txt));
-        });
-      }
-      incrementUsage();
-      return _pumpSse(resp, opts);
-    }).catch(function (err) {
-      if (err.name === 'AbortError') return;
-      // 流式失败 → 自动回退非流式
-      console.warn('[ai-client] 流式失败，回退非流式:', err.message);
-      _streamFallbackToChat(opts, cfg, model);
-    });
+    return _scheduleAiRequest(function () {
+      // P1-16：排队期间用户可能已中止（切换问题/停止生成）→ 静默结束
+      if (opts.signal && opts.signal.aborted) return Promise.resolve();
+      return fetchWithRetry(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ' + _getApiKey(),
+          'Accept': 'text/event-stream'
+        },
+        body: JSON.stringify(body),
+        signal: opts.signal
+      }).then(function (resp) {
+        if (!resp.ok) {
+          return resp.text().then(function (txt) {
+            throw new Error(_extractApiError(resp.status, txt));
+          });
+        }
+        incrementUsage();
+        return _pumpSse(resp, opts);
+      }).catch(function (err) {
+        if (err.name === 'AbortError') return;
+        // 流式失败 → 自动回退非流式
+        console.warn('[ai-client] 流式失败，回退非流式:', err.message);
+        _streamFallbackToChat(opts, cfg, model);
+      });
+    }, null); // 流式请求各调用方持有独立回调，不做结果去重（仅限流）
   }
 
   // 流式失败时回退到非流式（Metaso 等API流式不稳定时使用）
@@ -535,27 +653,30 @@
         body.subject_id = METASO_SUBJECT_ID;
       }
 
-    return fetchWithRetry(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': 'Bearer ' + _getApiKey()
-      },
-      body: JSON.stringify(body),
-      signal: opts.signal
-    }).then(function (resp) {
-      if (!resp.ok) {
-        return resp.text().then(function (txt) {
-          throw new Error(_extractApiError(resp.status, txt));
-        });
-      }
-      incrementUsage();
-      return resp.json();
-    }).catch(function (err) {
-      if (err.name === 'AbortError') throw err;
-      // 纯前端项目无后端，直连失败直接抛错
-      throw err;
-    });
+    // P1-16：非流式请求走调度器（限流 + 并发上限 + 同指纹并发去重）
+    return _scheduleAiRequest(function () {
+      return fetchWithRetry(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ' + _getApiKey()
+        },
+        body: JSON.stringify(body),
+        signal: opts.signal
+      }).then(function (resp) {
+        if (!resp.ok) {
+          return resp.text().then(function (txt) {
+            throw new Error(_extractApiError(resp.status, txt));
+          });
+        }
+        incrementUsage();
+        return resp.json();
+      }).catch(function (err) {
+        if (err.name === 'AbortError') throw err;
+        // 纯前端项目无后端，直连失败直接抛错
+        throw err;
+      });
+    }, _requestFingerprint(url, body));
   }
 
   // ====== SSE 解析（fetch + ReadableStream，兼容性强） ======
@@ -807,36 +928,40 @@
       stream: false
     });
 
-    return fetchWithRetry(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': 'Bearer ' + _getApiKey()
-      },
-      body: body,
-      signal: opts.signal
-    }).then(function (resp) {
-      if (!resp.ok) {
-        return resp.text().then(function (txt) {
-          throw new Error(_extractApiError(resp.status, txt));
-        });
-      }
-      incrementUsage();
-      return resp.json();
-    }).then(function (data) {
-      var text = '';
-      try {
-        text = data.choices[0].message.content || '';
-      } catch (e) {}
-      // 清理模型可能加的代码块包裹
-      text = text.replace(/^```[\w]*\n?/, '').replace(/\n?```$/, '').trim();
-      if (opts.onDone) opts.onDone(text);
-      return text;
-    }).catch(function (err) {
-      if (err.name === 'AbortError') return;
-      if (opts.onError) opts.onError(err);
-      throw err;
-    });
+    return _scheduleAiRequest(function () {
+      // P1-16：OCR 批量场景同样受速率限制/并发上限约束（防刷配额）
+      if (opts.signal && opts.signal.aborted) return Promise.resolve('');
+      return fetchWithRetry(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ' + _getApiKey()
+        },
+        body: body,
+        signal: opts.signal
+      }).then(function (resp) {
+        if (!resp.ok) {
+          return resp.text().then(function (txt) {
+            throw new Error(_extractApiError(resp.status, txt));
+          });
+        }
+        incrementUsage();
+        return resp.json();
+      }).then(function (data) {
+        var text = '';
+        try {
+          text = data.choices[0].message.content || '';
+        } catch (e) {}
+        // 清理模型可能加的代码块包裹
+        text = text.replace(/^```[\w]*\n?/, '').replace(/\n?```$/, '').trim();
+        if (opts.onDone) opts.onDone(text);
+        return text;
+      }).catch(function (err) {
+        if (err.name === 'AbortError') return '';
+        if (opts.onError) opts.onError(err);
+        throw err;
+      });
+    }, null); // 图片 base64 体积大，不做指纹去重（仅限流）
   }
 
   // 检查当前配置是否支持视觉 OCR
@@ -1041,6 +1166,8 @@
     // v3.1 新增
     withRetry: withRetry,
     callByStage: callByStage,
+    // P1-16（Issue #135）新增：请求调度器诊断接口（限流/并发/去重状态）
+    schedulerStats: _schedulerStats,
     // 让调用方（tutor/discussion）直接用，不用每次 new AbortController
     createAbortSignal: function () {
       var ctrl = new AbortController();

--- a/js/app.js
+++ b/js/app.js
@@ -287,6 +287,44 @@ function getRouteFromHash() {
 }
 
 /**
+ * P1-5（Issue #102）：处理 PWA 快捷方式的 ?page= 查询参数。
+ * manifest.json 的 shortcuts 指向 ./index.html?page=cards|quiz|diagnosis，
+ * 此前该参数无任何消费方（点击快捷方式只会落到首页）。
+ * 规则：
+ *   - 仅接受白名单映射（cards→/cards、quiz→/practice、diagnosis→/diagnosis），
+ *     未知值一律忽略，杜绝参数注入与任意跳转；
+ *   - 显式 hash 优先级高于 ?page=（用户带 hash 进入时不覆盖）；
+ *   - 用 history.replaceState 清理查询串，不产生多余历史记录。
+ */
+function _applyPageQueryParam() {
+  try {
+    if (!window.location.search) return;
+    var params = new URLSearchParams(window.location.search);
+    var page = params.get('page');
+    // 无论是否命中白名单都清掉查询串（一次性参数，避免刷新/分享时残留）
+    var baseUrl = window.location.pathname + window.location.hash;
+    if (!page) {
+      window.history.replaceState(null, '', baseUrl);
+      return;
+    }
+    var PAGE_ROUTE_WHITELIST = {
+      cards: '/cards',
+      quiz: '/practice',      // manifest 快捷方式「模拟练习」
+      diagnosis: '/diagnosis'
+    };
+    var target = PAGE_ROUTE_WHITELIST[String(page).toLowerCase()];
+    var hasExplicitHash = !!window.location.hash && window.location.hash !== '#/' && window.location.hash !== '#';
+    if (target && Routes[target] && !hasExplicitHash) {
+      // 先清查询串，再设置目标 hash（异步触发 hashchange → 常规路由）
+      window.history.replaceState(null, '', window.location.pathname);
+      window.location.hash = target;
+    } else {
+      window.history.replaceState(null, '', baseUrl);
+    }
+  } catch (e) { /* URL API 异常时静默忽略，保持默认路由 */ }
+}
+
+/**
  * 导航到指定路由
  * @param {string} route - 目标路由路径
  * @param {Object} [options] - 导航选项
@@ -1476,6 +1514,13 @@ function handleRoute(route) {
   _AppState.currentRoute = route;
   updatePageTitle(route);
   updateNavActive(route);
+
+  // #119 路由切换播报：SPA 视图切换对屏幕阅读器不可见（无整页加载），
+  // 用共享 aria-live 区播报目标页标题，让盲人用户感知导航已生效。
+  if (window.BioQuestA11y && typeof window.BioQuestA11y.announce === 'function') {
+    var _pageTitle = (routeCfg && routeCfg.title) ? routeCfg.title : '页面';
+    window.BioQuestA11y.announce(_pageTitle + '，已加载', 'polite');
+  }
 
   var target = _AppState.rootElement || document.getElementById('page-content');
   if (!target) {
@@ -4997,6 +5042,9 @@ function initApp() {
   _AppState._homeHTML = root.innerHTML;
   _AppState._countdownTimer = null;
 
+  // P1-5（Issue #102）：PWA 快捷方式 ?page= 白名单路由（读取后清理 URL）
+  _applyPageQueryParam();
+
   const route = getRouteFromHash();
 
   bindEvents();
@@ -5407,27 +5455,51 @@ function handleFeedbackSubmit() {
 
 /**
  * 显示 Toast 通知
+ * P1-12（Issue #121）增强：
+ *   - 第二参数兼容两种形态：'error'|'success'|'info'（类型化样式）或数字（毫秒时长）；
+ *     修复 habits.js 等处误传 'error' 字符串导致 setTimeout(…,'error') 被 coerce 成 0ms
+ *     立即消失、且错误无视觉区分的缺陷；
+ *   - 增加 role="alert" + aria-live，读屏用户可感知错误/状态提示。
+ * @param {string} message 提示文本
+ * @param {string|number} [typeOrDuration] 'error'|'success'|'info' 或毫秒数
+ * @param {number} [duration] 显示时长（毫秒），默认 success/info 3000、error 4500
  */
-function showToast(message, duration) {
+function showToast(message, typeOrDuration, duration) {
+  var type = 'info';
+  if (typeOrDuration === 'error' || typeOrDuration === 'success' || typeOrDuration === 'info') {
+    type = typeOrDuration;
+  } else if (typeof typeOrDuration === 'number' && typeOrDuration > 0) {
+    duration = typeOrDuration; // 旧签名 showToast(msg, ms) 兼容
+  }
+  if (!(typeof duration === 'number' && duration > 0)) {
+    duration = type === 'error' ? 4500 : 3000;
+  }
+
   var existing = document.getElementById('bioquest-toast');
   if (existing) existing.remove();
 
+  var typeBg = type === 'error' ? 'rgba(160,58,44,0.96)' : type === 'success' ? 'rgba(38,92,58,0.96)' : 'rgba(26,58,42,0.95)';
+  var typeBorder = type === 'error' ? 'rgba(200,90,70,0.5)' : type === 'success' ? 'rgba(90,180,120,0.5)' : 'rgba(58,140,92,0.3)';
+
   var toast = document.createElement('div');
   toast.id = 'bioquest-toast';
+  // P1-12：错误用 assertive（立即播报），其余 polite
+  toast.setAttribute('role', type === 'error' ? 'alert' : 'status');
+  toast.setAttribute('aria-live', type === 'error' ? 'assertive' : 'polite');
   toast.style.cssText = [
     'position:fixed',
     'bottom:80px',
     'left:50%',
     'transform:translateX(-50%)',
     'z-index:99999',
-    'background:rgba(26,58,42,0.95)',
+    'background:' + typeBg,
     'color:#fff',
     'padding:12px 24px',
     'border-radius:24px',
     'font-size:0.9rem',
     'font-weight:500',
     'box-shadow:0 4px 20px rgba(0,0,0,0.3)',
-    'border:1px solid rgba(58,140,92,0.3)',
+    'border:1px solid ' + typeBorder,
     'animation:toastSlideUp 0.3s ease',
     'max-width:90vw',
     'text-align:center',
@@ -5449,7 +5521,7 @@ function showToast(message, duration) {
     setTimeout(function() {
       if (toast.parentNode) toast.parentNode.removeChild(toast);
     }, 300);
-  }, duration || 3000);
+  }, duration);
 }
 
 /**

--- a/js/error-recovery.js
+++ b/js/error-recovery.js
@@ -59,12 +59,24 @@
     }
   });
 
-  // 未处理的 Promise 拒绝
+  // 未处理的 Promise 拒绝（#121：除记录日志外对用户可见）
+  var _lastRejectionToastAt = 0;
   window.addEventListener('unhandledrejection', function (event) {
     var reason = event.reason;
     var msg = reason && reason.message ? reason.message : String(reason);
     logError('[UnhandledRejection] ' + msg, '', 0, 0, reason);
     console.warn('[BioQuest] 未处理的 Promise 拒绝:', msg);
+    // 用户主动取消（AbortError）属正常流程，不打扰用户
+    if (reason && reason.name === 'AbortError') return;
+    // 节流：5 秒内最多提示一次，避免连续失败触发 toast 风暴
+    var now = Date.now();
+    if (now - _lastRejectionToastAt < 5000) return;
+    _lastRejectionToastAt = now;
+    if (typeof window.showToast === 'function') {
+      var brief = String(msg || '未知错误');
+      if (brief.length > 80) brief = brief.slice(0, 80) + '…';
+      window.showToast('操作遇到问题：' + brief, 'error');
+    }
   });
 
   console.log('[BioQuest] 全局错误恢复机制已启动');

--- a/js/tutor.js
+++ b/js/tutor.js
@@ -551,6 +551,13 @@ function _renderTutorMessages(container) {
     var msgEl = document.createElement('div');
     msgEl.className = 'tutor-msg tutor-msg--' + msg.role;
     var content = msg.role === 'user' ? escapeHtml(msg.content) : _tutorMarkdown(msg.content);
+    // P1-11（Issue #120）：AI 首字到达前的「思考中」三点占位
+    // （CSS .tutor-typing-dots 此前已注入样式但从未被创建——本处补上）
+    // 仅在「该消息正处于流式等待」时展示，收尾/出错（phase 回到 idle）即消失。
+    if (msg.role === 'ai' && !msg.content &&
+        _tutorState.streamPhase !== 'idle' && _tutorState.currentAiMsgId === msg.id) {
+      content = '<div class="tutor-typing-dots" role="status" aria-label="AI 正在思考"><span></span><span></span><span></span></div>';
+    }
     msgEl.innerHTML = '<div class="tutor-msg-bubble" id="msg-' + msg.id + '">' + content + '</div>';
     container.appendChild(msgEl);
   });
@@ -663,6 +670,9 @@ function _sendTutorMessage(text) {
     var span = document.createElement('span');
     span.className = 'tutor-streaming-text';
     span.textContent = newText;
+    // P1-11（Issue #120）：首字到达时移除「思考中」三点占位
+    var oldDots = bubble.querySelector('.tutor-typing-dots');
+    if (oldDots) oldDots.remove();
     var oldCursor = bubble.querySelector('.tutor-typing');
     if (oldCursor) oldCursor.remove();
     bubble.appendChild(span);
@@ -760,7 +770,7 @@ function _finishTutorStream(aiMsg, fullText, stopped) {
     _renderTutorMessages(messagesEl);
     var bubble = document.getElementById('msg-' + aiMsg.id);
     if (bubble) {
-      var tmpSpans = bubble.querySelectorAll('.tutor-streaming-text, .tutor-typing');
+      var tmpSpans = bubble.querySelectorAll('.tutor-streaming-text, .tutor-typing, .tutor-typing-dots');
       tmpSpans.forEach(function(s) { s.remove(); });
     }
   }

--- a/js/utils.js
+++ b/js/utils.js
@@ -1041,6 +1041,8 @@ function getQueryParams(url) {
  * 对来自 URL 的入参做白名单式校验与过滤：
  *   - 仅接受字符串
  *   - 剔除控制字符（含 \x00-\x1f、\x7f）与危险空白，防参数注入 / 控制字符污染渲染
+ *   - 剔除 HTML 标签定界符（< > 反引号），纵深防御：即使下游新增调用点
+ *     忘记 escapeHtml，也无法注入标记（引号保留给合法搜索词，由下游转义）
  *   - 限制最大长度，防超长参数滥用（刷接口 / 拖慢索引逻辑）
  * @param {*} value - 原始参数值
  * @param {number} [maxLen=100] - 允许的最大字符长度
@@ -1049,11 +1051,18 @@ function getQueryParams(url) {
 function sanitizeUrlParam(value, maxLen) {
   if (value == null || typeof value !== 'string') return null;
   // 剔除控制字符；保留正常空白、中文与可打印字符
-  const cleaned = value.replace(/[\u0000-\u001f\u007f]/g, '');
+  const cleaned = value
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .replace(/[<>`]/g, '');
   if (!cleaned) return null;
   const limit = (typeof maxLen === 'number' && maxLen > 0) ? maxLen : 100;
   if (cleaned.length > limit) return null;
   return cleaned;
+}
+
+// Q-03：注册到 BioQuest 命名空间（各调用点统一走 window.BioQuest.sanitizeUrlParam）
+if (typeof window !== 'undefined') {
+  BioQuest.sanitizeUrlParam = sanitizeUrlParam;
 }
 
 /**

--- a/microscope-3d/index.html
+++ b/microscope-3d/index.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#f7f5f0" />
     <meta name="description" content="BioQuest 3D 显微镜与真实显微视野联动原型" />
     <title>显微镜观察联动原型 · BioQuest</title>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "面向生物竞赛（联赛）备考的全栈学习平台，集知识卡片、模拟试题、学习分析、社区讨论于一体。",
   "scripts": {
     "test": "npm run test:anchor && npm run test:unit && npm run test:smoke && npm run test:bioid",
-    "test:unit": "jest --verbose",
+    "test:unit": "jest --verbose --coverage",
     "test:smoke": "node tests/wiki-smoke-test.cjs",
     "test:bioid": "node tests/bioid-quiz-smoke-test.cjs",
     "test:e2e": "node tests/e2e-smoke.js",

--- a/quiz.html
+++ b/quiz.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>模拟试题 - BioQuest</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/resources.html
+++ b/resources.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>学习资源 - BioQuest</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/study.html
+++ b/study.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN" data-theme="light">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>学习模块 - BioQuest</title>
   <meta http-equiv="refresh" content="0; url=index.html#/study">
   <script>location.replace('index.html#/study');</script>

--- a/sw.js
+++ b/sw.js
@@ -426,22 +426,30 @@ self.addEventListener('message', function (event) {
   }
   if (!data || typeof data !== 'object') return;
 
+  // #137 应答助手：优先经请求携带的 MessageChannel port 点对点回包
+  // （客户端 _sendSwMessage 通过 port1 监听应答；走 event.source.postMessage
+  //  广播时客户端永远收不到，只能等 3s 超时兜底）；无 port 再回退广播兼容旧协议。
+  function _reply(msg) {
+    if (event.ports && event.ports[0]) {
+      try { event.ports[0].postMessage(msg); return; } catch (e) {}
+    }
+    if (event.source) {
+      try { event.source.postMessage(msg); } catch (e) {}
+    }
+  }
+
   switch (data.type) {
     case 'SKIP_WAITING':
       self.skipWaiting();
       break;
     case 'GET_VERSION':
-      // 「检查更新」：返回外壳版本 + 题库缓存大小，供 UI 比对展示
-      if (event.source) {
-        event.source.postMessage({ type: 'VERSION', version: CACHE_VERSION });
-      }
+      // 「检查更新」：返回外壳版本，供 UI 比对展示
+      _reply({ type: 'VERSION', version: CACHE_VERSION });
       break;
     case 'PURGE_DATA_CACHE':
       // 「检查更新」发现题库新版本：清空题库 runtime cache，页面重取后自然落新缓存
       event.waitUntil(purgeDataCaches().then(function () {
-        if (event.source) {
-          event.source.postMessage({ type: 'DATA_CACHE_PURGED' });
-        }
+        _reply({ type: 'DATA_CACHE_PURGED' });
       }));
       break;
     default:

--- a/tests/unit/ai-scheduler.test.js
+++ b/tests/unit/ai-scheduler.test.js
@@ -1,0 +1,207 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Issue #135（P1-16）回归测试：AI 请求调度器
+ * 通过公共 API window.AiClient.chat() 验证：
+ *   1. 并发上限：同时在飞请求 ≤ AI_MAX_CONCURRENT(3)，超出排队
+ *   2. 速率限制：相邻请求最小启动间隔 600ms（滑动窗口节流）
+ *   3. 同指纹去重：相同 endpoint+body 的非流式请求在复用窗口内共享同一 Promise
+ *   4. 去重 TTL：复用窗口（5s）过后同指纹请求重新发起
+ *   5. 排队超时：等待超过 AI_QUEUE_TIMEOUT_MS(15s) 的排队请求被拒绝
+ */
+'use strict';
+
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const AI_CLIENT_PATH = path.join(ROOT, 'js/ai-client.js');
+
+/** 每个用例重新 require ai-client.js（闭包内调度器状态随之重置；Istanbul 可插桩） */
+function freshClient() {
+  try { localStorage.clear(); } catch (e) { /* ignore */ }
+  window.__bioquest_ai_key_memory__ = 'unit-test-byok-key-000111222';
+  jest.resetModules();
+  require(AI_CLIENT_PATH);
+  return window.AiClient;
+}
+
+/** fetch mock：返回手动放行的 deferred（挂起中的真实请求语义） */
+function installDeferredFetch() {
+  const deferreds = [];
+  global.fetch = jest.fn(() => new Promise((resolve) => {
+    deferreds.push({
+      resolve: () => resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ choices: [{ message: { content: 'ok-' + deferreds.length } }] })
+      })
+    });
+  }));
+  return deferreds;
+}
+
+/** 刷新微任务链（fetch→json→resolve→drain→starter 的 promise 链需要多个 tick） */
+async function flushAsync(times = 20) {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+/** 用不同内容构造去重指纹互异的 chat 调用 */
+function chatOf(Ai, content) {
+  return Ai.chat({ messages: [{ role: 'user', content }] });
+}
+
+describe('Issue #135：AI 请求调度器（限流 / 并发上限 / 去重）', () => {
+  beforeEach(() => { jest.useFakeTimers(); });
+  afterEach(() => { jest.useRealTimers(); });
+
+  test('并发上限 3 + 最小启动间隔 600ms：第 4 个请求排队等位', async () => {
+    const Ai = freshClient();
+    const deferreds = installDeferredFetch();
+
+    const pA = chatOf(Ai, 'A');
+    const pB = chatOf(Ai, 'B');
+    const pC = chatOf(Ai, 'C');
+    const pD = chatOf(Ai, 'D');
+    await flushAsync();
+
+    // 最小间隔节流：仅首个请求立即启动
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(610);
+    await flushAsync();
+    expect(global.fetch).toHaveBeenCalledTimes(2); // B 启动
+
+    jest.advanceTimersByTime(610);
+    await flushAsync();
+    expect(global.fetch).toHaveBeenCalledTimes(3); // C 启动；并发已满，D 排队
+    expect(Ai.schedulerStats().inFlight).toBe(3);
+    expect(Ai.schedulerStats().queued).toBe(1);
+
+    // 并发满时即使等待很久也不会有第 4 个请求发出
+    jest.advanceTimersByTime(5000);
+    await flushAsync();
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+
+    // A 完成 → 释放一个并发位；此时距上次启动已超过最小间隔，D 立即补位
+    deferreds[0].resolve();
+    await flushAsync();
+    expect(global.fetch).toHaveBeenCalledTimes(4); // D 补位启动
+    expect(Ai.schedulerStats().inFlight).toBe(3);
+
+    // 全部放行 → 所有调用方都能拿到结果（chat 返回 OpenAI 格式 JSON）
+    deferreds[1].resolve();
+    deferreds[2].resolve();
+    deferreds[3].resolve();
+    const results = await Promise.all([pA, pB, pC, pD]);
+    results.forEach((r) => {
+      expect(r.choices[0].message.content).toContain('ok-');
+    });
+    expect(Ai.schedulerStats().inFlight).toBe(0);
+    expect(Ai.schedulerStats().queued).toBe(0);
+  });
+
+  test('同指纹去重：相同请求体并发调用只发一次，且共享同一 Promise', async () => {
+    const Ai = freshClient();
+    const deferreds = installDeferredFetch();
+
+    const messages = [{ role: 'user', content: '线粒体的功能是什么？' }];
+    const p1 = Ai.chat({ messages });
+    const p2 = Ai.chat({ messages });
+    await flushAsync();
+
+    expect(global.fetch).toHaveBeenCalledTimes(1); // 只发一次真实请求
+    expect(p2).toBe(p1); // 共享同一 Promise 实例
+
+    deferreds[0].resolve();
+    await Promise.all([p1, p2]);
+    const data = await p1;
+    expect(data.choices[0].message.content).toContain('ok-');
+  });
+
+  test('不同指纹不去重：请求体不同则各自发起', async () => {
+    const Ai = freshClient();
+    installDeferredFetch();
+
+    const p1 = chatOf(Ai, '问题一');
+    const p2 = chatOf(Ai, '问题二');
+    await flushAsync();
+
+    jest.advanceTimersByTime(610);
+    await flushAsync();
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(p2).not.toBe(p1);
+  });
+
+  test('去重 TTL：复用窗口（5s）过期后同指纹请求重新发起', async () => {
+    const Ai = freshClient();
+    const deferreds = installDeferredFetch();
+
+    const messages = [{ role: 'user', content: '同一个问题' }];
+    const p1 = Ai.chat({ messages });
+    await flushAsync();
+    deferreds[0].resolve();
+    await p1;
+
+    jest.advanceTimersByTime(5100); // 超过 AI_DEDUP_TTL_MS
+    const p2 = Ai.chat({ messages });
+    await flushAsync();
+
+    expect(global.fetch).toHaveBeenCalledTimes(2); // 窗口已过 → 重新请求
+    deferreds[1].resolve();
+    await p2;
+  });
+
+  test('排队超时：等待超过 15s 的排队请求被拒绝并让位', async () => {
+    const Ai = freshClient();
+    const deferreds = installDeferredFetch();
+
+    // 占满 3 个并发位（A 立即启动；B、C 依次过最小间隔启动）
+    const pA = chatOf(Ai, 'A');
+    const pB = chatOf(Ai, 'B');
+    const pC = chatOf(Ai, 'C');
+    jest.advanceTimersByTime(610);
+    await flushAsync();
+    jest.advanceTimersByTime(610);
+    await flushAsync();
+    expect(Ai.schedulerStats().inFlight).toBe(3);
+
+    // t≈2020：D、E 相继排队（并发已满）
+    jest.advanceTimersByTime(800);
+    const pD = chatOf(Ai, 'D');
+    const pE = chatOf(Ai, 'E');
+    await flushAsync();
+    expect(Ai.schedulerStats().queued).toBe(2);
+
+    // t≈6020：A 完成 → drain：D（排队约 4s，未超时）补位启动，E 继续排队
+    jest.advanceTimersByTime(4000);
+    deferreds[0].resolve();
+    await flushAsync();
+    expect(global.fetch).toHaveBeenCalledTimes(4);
+
+    // t≈19020：E 已排队约 17s（> 15s 上限）。B 完成 → drain：E 被拒绝，不发第 5 个请求
+    jest.advanceTimersByTime(13000);
+    deferreds[1].resolve();
+    await flushAsync();
+    expect(global.fetch).toHaveBeenCalledTimes(4);
+    await expect(pE).rejects.toThrow('排队超时');
+
+    // 其余请求不受影响，正常完成
+    deferreds[2].resolve();
+    deferreds[3].resolve();
+    await Promise.all([pA, pB, pC, pD]);
+    expect(Ai.schedulerStats().queued).toBe(0);
+  });
+
+  test('schedulerStats 暴露调度器诊断信息', () => {
+    const Ai = freshClient();
+    installDeferredFetch();
+    const st = Ai.schedulerStats();
+    expect(st).toMatchObject({
+      inFlight: 0,
+      queued: 0,
+      dedupEntries: 0,
+      maxConcurrent: 3,
+      minIntervalMs: 600
+    });
+  });
+});

--- a/tests/unit/sanitize-url-param.test.js
+++ b/tests/unit/sanitize-url-param.test.js
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Issue #102（P1-5）回归测试：sanitizeUrlParam URL 参数清洗
+ * 验证：
+ *   1. 合法字符串（含中文/空格/引号）原样保留
+ *   2. 非字符串 / null / undefined → null
+ *   3. 控制字符（\x00-\x1f、\x7f）剔除
+ *   4. HTML 标签定界符 < > 与反引号剔除（纵深防御 XSS）
+ *   5. 清洗后为空 → null
+ *   6. 超长参数 → null（默认上限 100，可自定义）
+ */
+'use strict';
+
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+// 以 require 加载使 Istanbul 可插桩（此前 eval 方式覆盖率不可见）；
+// utils.js 顶层 'use strict' 使函数声明停留在模块作用域，
+// 受测函数经 window.BioQuest.sanitizeUrlParam 命名空间导出。
+require(path.join(ROOT, 'js/utils.js'));
+const sanitizeUrlParam = window.BioQuest.sanitizeUrlParam;
+
+describe('Issue #102：sanitizeUrlParam 参数清洗', () => {
+  test('合法字符串原样返回（中文、空格、单双引号均为合法搜索词）', () => {
+    expect(sanitizeUrlParam('细胞呼吸')).toBe('细胞呼吸');
+    expect(sanitizeUrlParam('C4 plant 光合作用')).toBe('C4 plant 光合作用');
+    expect(sanitizeUrlParam("O'Brien \"quoted\"")).toBe("O'Brien \"quoted\"");
+    expect(sanitizeUrlParam('a=b&c=d')).toBe('a=b&c=d');
+  });
+
+  test('非字符串输入一律返回 null', () => {
+    expect(sanitizeUrlParam(null)).toBeNull();
+    expect(sanitizeUrlParam(undefined)).toBeNull();
+    expect(sanitizeUrlParam(123)).toBeNull();
+    expect(sanitizeUrlParam({ q: 'x' })).toBeNull();
+    expect(sanitizeUrlParam(['x'])).toBeNull();
+    expect(sanitizeUrlParam(true)).toBeNull();
+  });
+
+  test('剔除控制字符（含 \x00-\x1f 与 \x7f）', () => {
+    expect(sanitizeUrlParam('a\x00b\x1fc\x7fd')).toBe('abcd');
+    expect(sanitizeUrlParam('q\x08\x0bword')).toBe('qword'); // \x0b 垂直制表也属控制字符
+    expect(sanitizeUrlParam('line\nbreak\ttab')).toBe('linebreaktab');
+  });
+
+  test('剔除 HTML 标签定界符与反引号（防标记注入）', () => {
+    expect(sanitizeUrlParam('<script>alert(1)</script>')).toBe('scriptalert(1)/script');
+    expect(sanitizeUrlParam('<img src=x onerror=alert(1)>')).toBe('img src=x onerror=alert(1)');
+    expect(sanitizeUrlParam('a<b>c')).toBe('abc');
+    expect(sanitizeUrlParam('`code`')).toBe('code');
+    expect(sanitizeUrlParam('``')).toBeNull();
+  });
+
+  test('清洗后为空字符串 → null', () => {
+    expect(sanitizeUrlParam('')).toBeNull();
+    expect(sanitizeUrlParam('<>')).toBeNull();
+    expect(sanitizeUrlParam('\x00\x00')).toBeNull();
+  });
+
+  test('长度限制：默认 100，超出返回 null', () => {
+    expect(sanitizeUrlParam('a'.repeat(100))).toBe('a'.repeat(100));
+    expect(sanitizeUrlParam('a'.repeat(101))).toBeNull();
+    // 清洗发生在长度校验前：定界符被剔除后不占长度
+    expect(sanitizeUrlParam('a'.repeat(50) + '<>'.repeat(25) + 'b'.repeat(25))).toBe('a'.repeat(50) + 'b'.repeat(25));
+  });
+
+  test('自定义 maxLen 与非法 maxLen 回落默认值', () => {
+    expect(sanitizeUrlParam('a'.repeat(10), 10)).toBe('a'.repeat(10));
+    expect(sanitizeUrlParam('a'.repeat(11), 10)).toBeNull();
+    // 非法 maxLen（<=0 / 非数字）回落 100
+    expect(sanitizeUrlParam('a'.repeat(100), 0)).toBe('a'.repeat(100));
+    expect(sanitizeUrlParam('a'.repeat(101), -5)).toBeNull();
+    expect(sanitizeUrlParam('a'.repeat(101), 'not-a-number')).toBeNull();
+  });
+});


### PR DESCRIPTION
## 概述

继 #15/#16/#17 修复之后，本 PR 一次性修复代码审计发现的全部 **P1 级缺陷**（#101/#102/#103/#119/#120/#121/#122/#126/#135/#137/#140/#141/#142），并在提交前完成全量校验。

## 修复明细

### 安全与健壮性
| Issue | 修复内容 |
|---|---|
| #135 | `ai-client.js` 新增请求调度器：并发上限 3、600ms 滑动窗口节流、15s 排队超时、同指纹 5s 去重——快速连点不再重复打配额 |
| #102 | `sanitizeUrlParam` 剔除 `<>` 与反引号（纵深防御 XSS）；新增 `_applyPageQueryParam` 白名单消费 PWA 快捷方式 `?page=` 死参数（cards/quiz/diagnosis），未知值一律忽略并清理 URL |
| #121 | `showToast` 类型化（error/success/info）+ `role`/`aria-live`；修复 habits.js 误传 `'error'` 导致 toast 0ms 消失；`unhandledrejection` 节流 toast 对用户可见（AbortError 豁免） |
| #142 | LICENSE 与官方 CC BY-NC-SA-4.0 逐字比对：还原 §2(a)(4)/§2(b)(3)/§3(a)(2)/§5/§6(c)/§8(b) 缺失文句、删除臆造的 §3(c)、**纠正 §7(a) 语义反转**（原文本错误地使 Licensor 受额外条款约束） |
| #101/#103 | 新增 `SECURITY.md`：无 Cookie 架构与 CSRF 免疫、会话加固（admin 5min TTL + RLS 边界）、BYOK Key 策略、CSP、已知风险面如实披露 |

### 无障碍与体验
- **#119** 路由切换经 `BioQuestA11y.announce` 播报页面标题（SPA 导航对屏幕阅读器可见）；删除从未被调用的 `makeLive` 死代码
- **#120** tutor AI 首字等待期渲染「思考中」三点动画（CSS 样式早已存在但 JS 从未创建）
- **#122** `globals.css` 用 `:where()` 零特异性实现通用按压反馈，纯兜底不覆盖任何页面级 `:active` 规则
- **#126** 全部 16 个 HTML：移除 `maximum-scale/minimum-scale`（不得阻止用户捏合缩放），统一补 `viewport-fit=cover`

### PWA 与数据分发
- **#137** `sw.js` 应答改经 MessageChannel port 点对点回包。**这是真实缺陷**：客户端 `_sendSwMessage` 一直用 port1 等应答，而 SW 用 `event.source.postMessage` 广播——应答永远收不到，`PURGE_DATA_CACHE` 只能空等 3s 超时兜底
- `data/manifest.json` git 锚点重锚定到上游 main 真实 commit `2474788`：原 `6b962d9` 是 fork 历史重写后的悬空 SHA，jsDelivr CDN 版本化 URL 将永久 404，且上游 CI `verify-manifest-anchor.js` 规则 3c 会直接 FAIL

### 测试与 CI（#140/#141）
- 新增 `tests/unit/ai-scheduler.test.js`（6 例：并发上限/节流/去重/TTL/排队超时/诊断接口）与 `tests/unit/sanitize-url-param.test.js`（7 例）
- 测试加载方式由 `(0, eval)(SRC)` 改为 `require`（Istanbul 可插桩，此前覆盖率恒 0%）
- `jest.config.cjs` 新增 `coverageThreshold` 门禁；CI `test:unit` 启用 `--coverage`

## 提交前校验（全部通过）

- ✅ `npm run lint:js`：0 错误
- ✅ 单元测试：**103/103**（13 套件，含新增 13 例）
- ✅ Playwright E2E 冒烟：8 路由渲染 + 重定向 + 0 页面错误
- ✅ 浏览器级功能回归 7/7（`?page=` 白名单跳转/注入忽略、aria-live 播报、toast 类型化、rejection 可见化、viewport、SW MessageChannel 应答实测返回 `{"type":"VERSION"}`）
- ✅ `verify-bio-shards.js` 全过；`bank/index/bioid-map` 分片零变更（生成器确定性保持）
- ⚠️ `verify-manifest-anchor.js` 在 fork 本地 FAIL 属预期（规则 2 检查 origin 与 repo 一致性）；合并后在上游 CI 中 origin=astrnox/BioQuest，锚点 commit 即 main HEAD，规则 3a 直接 PASS

Closes #101, Closes #102, Closes #103, Closes #119, Closes #120, Closes #121, Closes #122, Closes #126, Closes #135, Closes #137, Closes #140, Closes #141, Closes #142