### PR TITLE
fix: 首页首帧全宽，去除加载期左右白边

### DIFF
--- a/index.html
+++ b/index.html
@@ -451,7 +451,7 @@
   </nav>
 
   <main id="app-main">
-    <div id="page-content" class="page-content">
+    <div id="page-content" class="page-content page-content--home">
       <section class="hero" id="main-content" data-section="hero">
         <div class="hero-bg" id="heroCanvas"></div>
         <div class="hero-overlay"></div>


### PR DESCRIPTION
## 问题

首页加载时，"屏幕左右两边留下大白边"，且页面像卡着不动。

## 根因

初始加载时 `#page-content` 只有基础类 `.page-content`（定义 `max-width:1200px; margin:0 auto` 居中 + 左右内边距）。`page-content--home`（定义 `max-width:none; padding-left/right:0` 铺满全宽）只在 app.js 的 `handleRoute` 经 `requestAnimationFrame` 才会添加——而该回调要等大量 defer 脚本解析完才执行。

于是 boot 期间首页深色 hero 被限制在 1200px 宽的窄条内，左右两侧露出近似白色的 `body` cream 背景，形成大块白边；同时页面处于静态初稿（粒子动画未启动），观感即"卡住"。

## 改动

`index.html`：把 `page-content--home` 直接写入静态 `#page-content`，让首页第一帧就全宽，不再依赖 JS 后续补类。

```diff
-<div id="page-content" class="page-content">
+<div id="page-content" class="page-content page-content--home">
```

路由切换无回归：`handleRoute` 在进入非首页路由时会移除 `page-content--home`（app.js 中 `classList.remove(...)`），返回首页时再补回，`doRouteRender` 各分支保持原有行为。

## 影响

- 用户：首屏即为设计预期的全宽深色 hero，不再出现两侧白边/窄条的"卡住"感。
- 影响面：仅限首页首帧布局类名，不改动任何路由逻辑或样式表。

## 验证

- git diff 确认仅 1 行、仅 index.html。
- 对应 CSS 规则 `.page-content--home`（layout.css）明确覆盖 `.page-content` 的 max-width 与左右内边距，特异性一致、加载在后，判定生效。
- 沙箱内无法启动真实浏览器（无 Chromium/playwright 二进制），未做像素级回归截图；建议 CI/本地确认一次。
