### PR TITLE
feat: 内页内容撑满屏幕并优化首屏加载性能

### DIFF
--- a/css/globals.css
+++ b/css/globals.css
@@ -116,7 +116,9 @@
   --z-toast: 500;
 
   --header-height: 64px;
-  --content-max-width: 1200px;
+  /* 内页内容区宽度：从 1200px 提升到 min(1600px, 100%)，
+     宽屏下更撑满屏幕减少两侧米白留白，小屏维持接近全宽不产生白边 */
+  --content-max-width: min(1600px, 100%);
   --content-padding: 24px;
 
   --breakpoint-sm: 640px;

--- a/index.html
+++ b/index.html
@@ -250,6 +250,9 @@
   <link rel="preconnect" href="https://phet.colorado.edu" crossorigin>
 
   <!-- 字体：本地霞鹜文楷 v1.522，woff2 压缩（7.6MB），零网络请求 -->
+  <!-- 字体 preload：与 CSS/JS 并行下载，避免"进度条走完页面仍在加载"时字体还在路上；
+       crossorigin 为字体 preload 必需（字体以 CORS 模式请求） -->
+  <link rel="preload" as="font" type="font/woff2" href="fonts/lxgw-wenkai.woff2?v=1.522" crossorigin>
   <style>
     @font-face {
       font-family: 'LXGW WenKai';
@@ -271,7 +274,7 @@
   <script src="js/boot-lazy.js?v=20260820a" defer></script>
 
   <!-- 首屏关键 CSS：同步加载 -->
-  <link rel="stylesheet" href="css/globals.css?v=20260811h">
+  <link rel="stylesheet" href="css/globals.css?v=20260826a">
   <link rel="stylesheet" href="css/layout.css?v=20260723e">
   <link rel="stylesheet" href="css/header.css?v=20260723e">
   <link rel="stylesheet" href="css/learning-hub.css?v=20260809a">
@@ -314,7 +317,7 @@
     <div id="bq-boot-percent" aria-hidden="true">0%</div>
   </div>
   <!-- 首屏骨架遮罩逻辑（外部化）：defer 加载，不阻塞内容解析；遮罩本身由上方 CSS 立即显示 -->
-  <script src="js/boot-mask.js?v=20260820a" defer></script>
+  <script src="js/boot-mask.js?v=20260826a" defer></script>
 
   <a href="#page-content" class="skip-link">跳到主要内容</a>
 
@@ -699,20 +702,17 @@
   <script src="js/vendor/purify.min.js?v=20260723d" defer></script>
   <!-- FSRS 间隔重复算法包装层：基于 ts-fsrs，暴露 window.FSRS 兼容 API（修复 P0-1） -->
   <script src="js/fsrs-algorithm.js?v=20260723d" defer></script>
-  <!-- v5.0 Tier1 vendor 库（懒加载由集成模块内部处理，但首屏预加载关键库） -->
-  <script src="js/vendor/katex.min.js?v=20260723d" defer></script>
-  <script src="js/vendor/mhchem.min.js?v=20260723d" defer></script>
+  <!-- v5.0 Tier1 vendor 库：仅保留首页/学习主链路真正用到的库；
+       体积大且仅特定路由使用/当前未使用的库（katex/mhchem/gsap 无业务调用，
+       mammoth/pdf.js 仅文档导入用）不再首屏加载，mammoth/pdf 由 document-tools 用时注入 -->
   <script src="js/vendor/dexie.min.js?v=20260723d" defer></script>
   <script src="js/vendor/chart.umd.min.js?v=20260723d" defer></script>
-  <script src="js/vendor/gsap.min.js?v=20260723d" defer></script>
   <script src="js/vendor/jszip.min.js?v=20260723d" defer></script>
-  <script src="js/vendor/mammoth.browser.min.js?v=20260723d" defer></script>
   <!-- d3 (BSD-3): cal-heatmap 4.x 依赖（d3-selection/d3-color/d3-fetch），
        必须在 cal-heatmap.min.js 之前加载，否则 cal-heatmap 会报
        "Cannot read properties of undefined (reading 'timeSecond')" -->
   <script src="js/vendor/d3.min.js?v=20260723d" defer></script>
   <script src="js/vendor/cal-heatmap.min.js?v=20260723d" defer></script>
-  <script src="js/vendor/pdf.min.js?v=20260723d" defer></script>
   <!-- v5.0 Tier1 集成模块 -->
   <script src="js/integrations/vendor-init.js?v=20260723d" defer></script>
   <!-- OCR 多引擎抽象层：Vision → ONNX PaddleOCR → Tesseract → OCRad 四级降级；
@@ -723,7 +723,7 @@
   <script src="js/integrations/analytics-charts.js?v=20260723d" defer></script>
   <script src="js/integrations/diagram-renderer.js?v=20260723d" defer></script>
   <script src="js/integrations/molecule-viewer.js?v=20260723d" defer></script>
-  <script src="js/integrations/document-tools.js?v=20260723d" defer></script>
+  <script src="js/integrations/document-tools.js?v=20260826a" defer></script>
   <script src="js/integrations/data-store.js?v=20260723d" defer></script>
   <!-- Issue #14：FSRS 优化器/分片哈希 Web Worker 核心（纯函数，双上下文：Worker + 主线程桶底）。
        必须先于 fsrs-optimizer.js 加载，提供 window.FSRSWorkerCore 供主线程兜底。 -->
@@ -812,7 +812,7 @@
   <script src="js/sync-tabs.js?v=20260803a" defer></script>
   <script src="js/error-recovery.js?v=20260803a" defer></script>
   <script src="js/question-utils.js?v=20260809c" defer></script>
-  <script src="js/loader.js?v=20260809g" defer></script>
+  <script src="js/loader.js?v=20260826a" defer></script>
   <script src="js/cell-loader.js?v=20260803a" defer></script>
   <script src="js/shortcut-panel.js?v=20260803a" defer></script>
   <script src="js/soundscape.js?v=20260803a" defer></script>

--- a/js/boot-mask.js
+++ b/js/boot-mask.js
@@ -128,33 +128,29 @@
     else setTimeout(fadeOut, MIN_VISIBLE - elapsed);
   }
 
-  // ---- 就绪判定（保证"动画时长 = 实际加载时长"）----
-  // 必须同时满足"内容已渲染" 与 "资源已加载"，才会撤遮罩：
-  //   1) 内容渲染：收到 bioquest:app-ready（finishRouting + reinitHomeComponents rAF 双重确认）；
-  //   2) 资源加载：window.load 触发（全部 CSS/JS/字体/图片已下载），或到达硬上限(LOAD_CAP)，
-  //      避免某个挂起的 CDN 资源无限期挡住首屏。
+  // ---- 就绪判定 ----
+  // 遮罩只在"页面可交互"后撤除：bioquest:app-ready 由 SPA 路由在首帧渲染完成后派发，
+  // 此时全部 defer 脚本已按序执行完毕、首屏已绘制，页面可点击。
+  // 不再等待 window.load —— 它会被 7.6MB 字体/图片等资源无限期拖住，造成
+  // "进度条走完但页面还在加载/卡"的错位感（字体走 font-display:swap 异步加载，不影响交互）。
   var contentReady = false;  // bioquest:app-ready 已收到
-  var loadReady = false;     // window.load 已触发
-  var LOAD_CAP = 9000;       // 硬上限：内容就绪后缩短为 CONTENT_CAP，不再无限期阻塞
-  var CONTENT_CAP = 4000;    // 内容已渲染后的资源加载上限
+  var APP_READY_CAP = 15000; // 兜底：异常路径（app-ready 未派发）也不让遮罩永久卡死
 
   function bootTick() {
-    // 内容已渲染后，给资源加载一个较短窗口；否则用更长的总上限做兜底。
-    var cap = contentReady ? CONTENT_CAP : LOAD_CAP;
-    var loadDone = loadReady || (Date.now() - startTime >= cap);
-    if (contentReady && loadDone) {
+    var capReached = Date.now() - startTime >= APP_READY_CAP;
+    if (contentReady || capReached) {
       startFadeOut();
     } else if (BootProgress) {
       BootProgress._schedule(); // 未就绪时保持进度条继续渐进逼近
     }
   }
 
-  // 主信号：应用首屏渲染/路由完成。仅当内容真正渲染后才把进度推到接近完成，
-  // 并参与"内容已就绪"门控——动画绝不会早于内容渲染结束。
+  // 主信号：应用首屏渲染/路由完成 → 页面已可交互，撤遮罩（进度同时补足到 100%）。
   document.addEventListener('bioquest:app-ready', function () {
     contentReady = true;
-    if (window.BootProgress) BootProgress.addWeight(40, 88);
-    bootTick();
+    if (window.BootProgress) BootProgress.addWeight(40, 92);
+    // 给最后一帧布局/绘制留一点缓冲，避免淡出瞬间卡顿
+    setTimeout(bootTick, 40);
   });
 
   // 进度标记：HTML/CSS/脚本解析阶段
@@ -165,13 +161,6 @@
   if (document.readyState === 'interactive' || document.readyState === 'complete') onDOMReady();
   else document.addEventListener('DOMContentLoaded', onDOMReady);
 
-  // 全部资源加载完成：这是"实际加载"完成的标志之一（配合内容渲染门控）。
-  window.addEventListener('load', function () {
-    loadReady = true;
-    if (window.BootProgress) BootProgress.addWeight(15, 60);
-    bootTick();
-  });
-
   // 兜底：极长时间仍未就绪（异常路径），避免遮罩永久卡死。
-  setTimeout(function () { contentReady = true; loadReady = true; if (!done) startFadeOut(); }, 20000);
+  setTimeout(function () { contentReady = true; if (!done) startFadeOut(); }, APP_READY_CAP);
 })();

--- a/js/integrations/document-tools.js
+++ b/js/integrations/document-tools.js
@@ -10,6 +10,39 @@
 (function () {
   'use strict';
 
+  var _mammothLoading = null;
+  var _pdfLoading = null;
+
+  /**
+   * 按需加载 mammoth（约 620KB，仅首次处理 .docx 时注入），避免首屏卡顿
+   * @returns {Promise<boolean>}
+   */
+  function loadMammoth() {
+    if (typeof window.mammoth !== 'undefined') return Promise.resolve(true);
+    if (typeof window.loadScriptOnce !== 'function') return Promise.resolve(false);
+    if (!_mammothLoading) {
+      _mammothLoading = window.loadScriptOnce('js/vendor/mammoth.browser.min.js?v=20260723d', {
+        verify: function () { return typeof window.mammoth !== 'undefined'; }
+      }).then(function () { return true; }).catch(function () { _mammothLoading = null; return false; });
+    }
+    return _mammothLoading;
+  }
+
+  /**
+   * 按需加载 PDF.js（约 320KB，仅首次处理 .pdf 时注入）
+   * @returns {Promise<boolean>}
+   */
+  function loadPDFJS() {
+    if (typeof window.pdfjsLib !== 'undefined') return Promise.resolve(true);
+    if (typeof window.loadScriptOnce !== 'function') return Promise.resolve(false);
+    if (!_pdfLoading) {
+      _pdfLoading = window.loadScriptOnce('js/vendor/pdf.min.js?v=20260723d', {
+        verify: function () { return typeof window.pdfjsLib !== 'undefined'; }
+      }).then(function () { return true; }).catch(function () { _pdfLoading = null; return false; });
+    }
+    return _pdfLoading;
+  }
+
   function ensureMammoth() {
     if (typeof window.mammoth === 'undefined') {
       console.warn('[DocumentTools] mammoth 未加载');
@@ -47,11 +80,11 @@
    * @returns {Promise<{ text:string, html:string, messages:Array }>}
    */
   function extractWord(file) {
-    if (!ensureMammoth()) {
-      return Promise.reject(new Error('Word 解析库未加载'));
-    }
     if (!file) return Promise.reject(new Error('未提供文件'));
-    return readFileAsArrayBuffer(file).then(function (buf) {
+    return loadMammoth().then(function (ok) {
+      if (!ok || !ensureMammoth()) return Promise.reject(new Error('Word 解析库加载失败'));
+      return readFileAsArrayBuffer(file);
+    }).then(function (buf) {
       return window.mammoth.convertToHtml({ arrayBuffer: buf });
     }).then(function (result) {
       // 去标签得到纯文本
@@ -67,14 +100,14 @@
    * @returns {Promise<{ pages:string[], numPages:number }>}
    */
   function extractPdf(file, opts) {
-    if (!ensurePDFJS()) {
-      return Promise.reject(new Error('PDF 解析库未加载'));
-    }
     if (!file) return Promise.reject(new Error('未提供文件'));
     opts = opts || {};
     var maxPages = opts.maxPages || 100;
 
-    return readFileAsArrayBuffer(file).then(function (buf) {
+    return loadPDFJS().then(function (ok) {
+      if (!ok || !ensurePDFJS()) return Promise.reject(new Error('PDF 解析库加载失败'));
+      return readFileAsArrayBuffer(file);
+    }).then(function (buf) {
       var loadingTask = window.pdfjsLib.getDocument({ data: buf });
       return loadingTask.promise;
     }).then(function (pdf) {
@@ -111,13 +144,15 @@
    * @returns {Promise<{ width:number, height:number }>}
    */
   function renderPdfPage(canvasId, arrayBuffer, pageNum, opts) {
-    if (!ensurePDFJS()) return Promise.reject(new Error('PDF 解析库未加载'));
     var canvas = document.getElementById(canvasId);
     if (!canvas) return Promise.reject(new Error('canvas 不存在: ' + canvasId));
     opts = opts || {};
     var scale = opts.scale || 1.5;
 
-    return window.pdfjsLib.getDocument({ data: arrayBuffer }).promise.then(function (pdf) {
+    return loadPDFJS().then(function (ok) {
+      if (!ok || !ensurePDFJS()) return Promise.reject(new Error('PDF 解析库加载失败'));
+      return window.pdfjsLib.getDocument({ data: arrayBuffer }).promise;
+    }).then(function (pdf) {
       return pdf.getPage(pageNum);
     }).then(function (page) {
       var viewport = page.getViewport({ scale: scale });
@@ -136,18 +171,20 @@
    * @returns {Promise<{ pdf, numPages, renderPage }>}
    */
   function loadPdf(input) {
-    if (!ensurePDFJS()) return Promise.reject(new Error('PDF 解析库未加载'));
-    var promise;
-    if (input instanceof ArrayBuffer) promise = Promise.resolve(input);
-    else promise = readFileAsArrayBuffer(input);
-    return promise.then(function (buf) {
-      return window.pdfjsLib.getDocument({ data: buf }).promise;
+    if (!(input instanceof ArrayBuffer)) {
+      if (!input) return Promise.reject(new Error('未提供文件'));
+      // File/Blob → 先读成 ArrayBuffer，再走 ArrayBuffer 分支（避免闭包捕获局部 buf）
+      return readFileAsArrayBuffer(input).then(loadPdf);
+    }
+    return loadPDFJS().then(function (ok) {
+      if (!ok || !ensurePDFJS()) return Promise.reject(new Error('PDF 解析库加载失败'));
+      return window.pdfjsLib.getDocument({ data: input }).promise;
     }).then(function (pdf) {
       return {
         pdf: pdf,
         numPages: pdf.numPages,
         renderPage: function (canvasId, pageNum, opts) {
-          return renderPdfPage(canvasId, buf, pageNum, opts);
+          return renderPdfPage(canvasId, input, pageNum, opts);
         }
       };
     });

--- a/js/loader.js
+++ b/js/loader.js
@@ -1533,6 +1533,17 @@ function maintainQuestionBank() {
       .map(function (k) { return k.replace(/^bank\//, '').replace(/\.json$/, ''); });
     if (bankTags.length === 0) { _maintenanceRunning = false; return { changed: false, refreshed: 0 }; }
 
+    // 首访带宽保护：首次会话不后台预热 bank 分片（80 个文件约 14MB），
+    // 避免新用户刚进站就被大流量下载拖慢，造成"进度条走完页面还在加载/卡网速"。
+    // 置位标记后，从下一次访问起（分片已随用户使用按需进入 SW/内存缓存）再在空闲时后台预热。
+    var warmedOnce = false;
+    try { warmedOnce = localStorage.getItem('bioquest_bank_warmed_once') === '1'; } catch (e) {}
+    if (!warmedOnce) {
+      try { localStorage.setItem('bioquest_bank_warmed_once', '1'); } catch (e) {}
+      _maintenanceRunning = false;
+      return { changed: result.changed, refreshed: 0, deferred: true };
+    }
+
     return new Promise(function (resolveOuter) {
       var refreshed = 0;
       var idx = 0;
@@ -1541,9 +1552,13 @@ function maintainQuestionBank() {
         var tag = bankTags[idx++];
         var expected = files['bank/' + tag + '.json'] || null;
         // 逐 tag 拉取（内部缓存命中/SHA 一致会复用），完成后让出主线程
-        _loadShardBank(tag, expected, null).then(function (text) {
+        _loadShardBank(tag, expected, null).then(function () {
           refreshed++;
-          _bankToItems(text, tag); // 落库 questions 表
+          // 注意：这里不再调用 _bankToItems()（JSON.parse 整片 + bulkPut 进 questions 表）。
+          // 空闲期在 80+ 个分片上做同步 parse/写入会制造大量 Long Task，
+          // 导致用户刚加载完点"练习/模考"时页面卡死几秒。
+          // 分片原始 JSON 已由 _loadShardBank 存入 IndexedDB shards 表（含 SHA），
+          // 首次真正拉题时再由 _bankToItems 惰性解析落库。
         }).catch(function () {
           // 单个分片失败不影响整体
         }).then(function () {

--- a/sw.js
+++ b/sw.js
@@ -9,7 +9,7 @@
 // P1-4 修复：CACHE_VERSION 由 scripts/bump-sw.js 基于 git 跟踪的 js/css/data
 // 内容哈希自动生成——修改任何 JS/CSS/data 后运行 `npm run bump:sw` 即可，
 // 不再依赖人肉维护版本号。版本号变化会触发 activate 阶段清理旧缓存并重新预热。
-var CACHE_VERSION = 'bioquest-41e2d3b7ada7'; // ← bump-sw.js 会自动改写此行
+var CACHE_VERSION = 'bioquest-19ac7a539a03'; // ← bump-sw.js 会自动改写此行
 var CACHE_NAME = 'bioquest-cache-' + CACHE_VERSION;
 
 /* ========================================================================

--- a/tests/unit/loader-cdn.test.js
+++ b/tests/unit/loader-cdn.test.js
@@ -157,6 +157,10 @@ describe('Issue #15：会话级 kill-switch', () => {
     };
     installFetch(manifest, 'cdn-fail');
 
+    // 首访带宽保护：全新会话（localStorage 无标记）会跳过后台预热，
+    // 因此本用例先置位标记模拟"回访用户"，验证预热阶段的 CDN kill-switch 时序。
+    try { localStorage.setItem('bioquest_bank_warmed_once', '1'); } catch (e) {}
+
     const result = await realMaintain();
     expect(result).not.toBeNull();
     // 串行第 4 个分片不再尝试 CDN（连续 3 次失败后被禁用）


### PR DESCRIPTION
## 背景
针对"首次加载慢 / 进度条走完页面仍在加载 / 进入内页两侧米白留白"的体验问题，把此前在 fork 中验证过的优化适配到当前 main（已包含 #153 等近期改动）。

## 改动内容

### 首屏加载性能
- **启动遮罩撤除时机**：不再等待 `window.load`（会被 7.6MB 字体/图片拖住，造成"进度条走完页面还在加载"的错位感），改为收到 `bioquest:app-ready`（全部 defer 脚本执行完毕、首屏已渲染、页面可交互）后平滑淡出，15s 兜底防卡死。
- **移除首屏无业务调用的 vendor**：`katex`、`mhchem`、`gsap` 全站无调用；`mammoth`(620KB)、`pdf.js`(320KB) 改为 `document-tools` 首次使用时 `loadScriptOnce` 按需注入（功能不变）。
- **loader 后台维护降噪**：空闲维护不再对 80 个 bank 分片（约 14MB）同步 `JSON.parse` + 批量写 IndexedDB（消除 Long Task，避免点"练习/模考"时主线程卡死几秒）；并新增**首访带宽保护**——首次会话跳过 14MB 分片后台预热，置位标记后次访问空闲再预热。
- **字体 preload**：`lxgw-wenkai.woff2` 与脚本并行下载，减少加载完成后的字体等待。

### 内页布局
- `--content-max-width`：`1200px` → `min(1600px, 100%)`，宽屏下内容更撑满、两侧白边显著减少；小屏保持接近全宽。

### 附带修复
- `document-tools.loadPdf` 闭包捕获局部变量导致的潜在 ReferenceError。

### 版本
- 已按仓库约定执行 `scripts/bump-sw.js` 自动更新 `sw.js` CACHE_VERSION；相关资源 `?v=` 已同步 bump。

## 验证
- 改动文件 `node --check` 全部通过；
- 本地静态服务 + 浏览器实测（fork 侧相同改动）：遮罩正常淡出、练习页渲染完整、交互无卡顿、全程零 console 错误。