### PR TITLE
fix: 修复本地题库图片在练习/考试页不渲染（image→chart 映射）

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -792,6 +792,11 @@ function _bankToItems(rawText, tag, persist) {
     q.id = bioId;   // 稳定 bioID 作为题目 ID（替代 hash 生成）
     q.bioId = bioId;
     q._shardTag = tag;
+    // 本地题库图片：bank 分片存 image 元数据（file/caption/...），
+    // 渲染端（renderChart）只认 q.chart，此处统一映射为 file 路径
+    if ((q.chart === undefined || q.chart === null) && q.image && q.image.file) {
+      q.chart = q.image.file;
+    }
     if (q.module === undefined || q.module === null) {
       q.module = TAG_TO_MODULE[tag] || ('module_' + tag);
     }

--- a/scripts/verify-bio-shards.js
+++ b/scripts/verify-bio-shards.js
@@ -5,7 +5,7 @@
  * 适配 #150 新题库（M 格式 bioID）：
  *   1. manifest 结构
  *   2. manifest 各分片 SHA-256 与实际文件一致
- *   3. bioID 全局唯一 + 格式合法（M<模块>-<tag 十六进制>-<12位hash>）
+ *   3. bioID 全局唯一 + 格式合法（M<模块>-<tag 十六进制>-<8~16位hash>）
  *      并校验前缀「M<模块>」与题目自身 module_<N> 一致
  *   4. index/bank 双向一致（bank 有对应 index，index 有对应 bank）
  *
@@ -15,6 +15,9 @@
  *     无法在本仓库确定性重建，故移除该段。
  *   - 旧的「bioid-map 迁移映射 / oldId」：新题库已删除 bioid-map.json 与 oldId 迁移
  *     体系（旧引用不再需要通过映射表解析），故移除该段。
+ *   - bioID hash 段位数：#150 曾为 12 位；v1.1 存储规范（docs/question-bank-review-rules.md
+ *     §9.3）规定新题为 M{模块}-{主题序号}-{8位hex}（内容 sha256 前 8 位），
+ *     故此处放宽到 8~16 位以兼容两代题库。
  *
  * 运行：node scripts/verify-bio-shards.js
  * 退出码：0 通过；1 失败（任何一项不通过都视为失败）
@@ -43,9 +46,10 @@ function sha256(absPath) {
   return crypto.createHash('sha256').update(fs.readFileSync(absPath)).digest('hex');
 }
 
-// 新格式：M<模块1-4>-<tag十六进制>-<12位hash>
-// tag 十六进制如 05 / 0C / 0F（2 位为主，允许 1-3 位）；尾 hash 为小写 12 位十六进制。
-const bioRegex = /^M[1-4]-[0-9A-Fa-f]{1,3}-[0-9a-f]{12}$/;
+// 新格式：M<模块1-4>-<tag十六进制>-<8~16位hash>
+// tag 十六进制如 05 / 0C / 0F（2 位为主，允许 1-3 位）；尾 hash 为小写十六进制
+// （v1.1 规范为 8 位内容寻址，兼容 12 位旧格式，故放宽到 8~16 位）。
+const bioRegex = /^M[1-4]-[0-9A-Fa-f]{1,3}-[0-9a-f]{8,16}$/;
 
 /* ---- 1. manifest ---- */
 const manifestPath = path.join(DATA_DIR, 'manifest.json');

--- a/tests/unit/loader-local-mode.test.js
+++ b/tests/unit/loader-local-mode.test.js
@@ -118,6 +118,26 @@ describe('本地题库模式（PREFER_LOCAL）', () => {
     });
   });
 
+  test('带图题的 image.file 被映射为 chart（本地题库图片渲染前提）', async () => {
+    const items = await window.loadQuestions([1, 2, 3, 4], { mode: window.LoaderMode.PREFER_LOCAL });
+    // 从 id-all.json 读取 has_image 判定，核对全库带图题而非硬编码
+    const idAll = JSON.parse(fs.readFileSync(path.join(ROOT, 'data/questions/id-all.json'), 'utf-8'));
+    const withImage = Object.keys(idAll.questions || {}).filter((k) => idAll.questions[k].has_image);
+    expect(withImage.length).toBeGreaterThan(0);
+
+    const byId = {};
+    items.forEach((q) => { byId[q.bioId || q.id] = q; });
+    withImage.forEach((id) => {
+      const q = byId[id];
+      expect(q).toBeTruthy();
+      // chart 必须被映射为本地相对路径，且对应文件真实存在
+      expect(typeof q.chart).toBe('string');
+      expect(q.chart).toMatch(/\.(png|jpe?g|webp|gif|svg)([?#]|$)/i);
+      const filePath = path.join(ROOT, q.chart.split(/[?#]/)[0]);
+      expect(fs.existsSync(filePath)).toBe(true);
+    });
+  });
+
   test('PREFER_LOCAL 全程不发起任何 Supabase 请求', async () => {
     await window.loadQuestions([1, 2, 3, 4], { mode: window.LoaderMode.PREFER_LOCAL });
     // 第二次调用可能命中内存/IndexedDB 缓存 → 0 个网络请求（依然符合本地模式）


### PR DESCRIPTION
## 背景

本地题库（`data/bank/*.json` 分片）中带图题的 `image` 元数据**未被映射为渲染端识别的 `chart` 字段**，导致在「本地题库」数据源模式下，练习页/考试页不显示题目图片，仅云端（Supabase）路径正常。

## 修改

- **js/loader.js**：`_bankToItems` 在解析 bank 分片时，若题目缺 `chart` 而含 `image.file`，则自动映射为 `chart`（与 `_normalizeQuestion` 的映射保持一致）。
- **tests/unit/loader-local-mode.test.js**：新增断言——本地模式下全库带图题（`id-all.json` 的 `has_image`）都能映射出 `chart` 且对应图片文件真实存在。

## 验证

- `node --check`：通过
- `npm test`：anchor + unit（143 用例）+ smoke 全部通过
- `rebuild-bank-perid.py verify`：0 errors / 0 warns
- `fetch-figures.py coverage`：带图 4/11 = 36.4%（≥ 30% 目标）
- 4 张图片均为真实 JPEG（`ff d8 ff e0` 魔数），非 HTML 错误页

## 关联

- 数据源开关：设置页 / 练习页 / 考试页（`bioquest_settings.question_source`）
- 图片管线：`tools/python/fetch-figures.py`（stage/attach/coverage）