### PR TITLE
fix: 修复 7 个 P3 遗留 issue（成就面板/主题过渡/空状态/动画性能/懒加载/提交规范/三方资源）

### DIFF
--- a/cards.html
+++ b/cards.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="css/header.css">
   <link rel="stylesheet" href="css/footer.css">
   <link rel="stylesheet" href="css/cards.css?v=20260618a">
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.115.0" integrity="sha384-EyR2P0dlmjnEGcm9xcjdAn0VedZpRHEwDLP9oSS6wYMvzHBHkUrvgonveazJ/sSx" crossorigin="anonymous"></script>
   <script src="js/supabase-client.js?v=20260814c"></script>
   <script src="js/supabase.js?v=20260618a"></script>
   <script src="js/utils.js?v=20260814b"></script>

--- a/css/bundle-core.css
+++ b/css/bundle-core.css
@@ -2,7 +2,7 @@
  * BioQuest — 首屏同步 CSS 合并包（Issue #108，由
  * scripts/build-css-bundle.js 自动生成，勿手改。
  * 合并源：globals.css + layout.css + header.css + learning-hub.css + home.css + debug-fix.css
- * 生成时间：2026-09-05T11:01:14.103Z
+ * 生成时间：2026-09-06T07:24:12.494Z
  * ============================================================ */
 
 /* ---------- 来源: css/globals.css ---------- */
@@ -1810,10 +1810,13 @@ body {
 }
 .pwd-attack-fill {
   height: 100%;
-  width: 0;
+  width: 100%;
   background: linear-gradient(90deg, #d63a2a, #e87a3a, #e8c43a, #a8d63a, #3a8c5c);
   border-radius: 3px;
-  transition: width 0.15s linear, background 0.3s;
+  transform-origin: left center;
+  will-change: transform;
+  /* #118（P3-3）：进度改用 transform: scaleX（合成层动画），避免逐帧改 width 触发重排 */
+  transition: transform 0.15s linear, background 0.3s;
 }
 .pwd-attack-stat {
   font-size: 0.72rem;

--- a/css/globals.css
+++ b/css/globals.css
@@ -1802,10 +1802,13 @@ body {
 }
 .pwd-attack-fill {
   height: 100%;
-  width: 0;
+  width: 100%;
   background: linear-gradient(90deg, #d63a2a, #e87a3a, #e8c43a, #a8d63a, #3a8c5c);
   border-radius: 3px;
-  transition: width 0.15s linear, background 0.3s;
+  transform-origin: left center;
+  will-change: transform;
+  /* #118（P3-3）：进度改用 transform: scaleX（合成层动画），避免逐帧改 width 触发重排 */
+  transition: transform 0.15s linear, background 0.3s;
 }
 .pwd-attack-stat {
   font-size: 0.72rem;

--- a/css/practice.css
+++ b/css/practice.css
@@ -773,15 +773,19 @@
 
 .practice-loading-fill {
   height: 100%;
+  width: 100%;
   background-color: var(--color-amber);
   border-radius: 99px;
+  transform-origin: left center;
+  will-change: transform;
+  /* #118（P3-3）：练习加载条动画由 width 改为 transform: scaleX，仅触发合成层，避免重排 */
   animation: practice-loading-pulse 1.4s ease-in-out infinite;
 }
 
 @keyframes practice-loading-pulse {
-  0% { width: 0%; }
-  50% { width: 70%; }
-  100% { width: 100%; }
+  0% { transform: scaleX(0); }
+  50% { transform: scaleX(0.7); }
+  100% { transform: scaleX(1); }
 }
 
 /* ============================================================

--- a/css/theme-transition.css
+++ b/css/theme-transition.css
@@ -11,7 +11,10 @@ html.bq-theme-anim *::after {
     background-color .3s ease,
     color .3s ease,
     border-color .3s ease,
-    box-shadow .3s ease !important;
+    box-shadow .3s ease,
+    opacity .3s ease,
+    fill .3s ease,
+    stroke .3s ease !important;
 }
 
 /* will-change 提示：预先告知浏览器参与过渡的元素，减少切换时的合成/闪烁 */

--- a/data/third-party-domains.txt
+++ b/data/third-party-domains.txt
@@ -5,8 +5,13 @@
 #       是否带 SRI 完整性由 scripts/verify-third-party.js 单独校验。
 
 # ---- CDN 静态资源（css/js 加载；外链样式表/脚本必须带 SRI integrity）----
-cdn.jsdelivr.net        # 主 CDN：KaTeX、vue 等；index.html 实际使用
+cdn.jsdelivr.net        # 主 CDN：KaTeX、vue、supabase-js 等；index 及子页面实际使用
 cdnjs.cloudflare.com    # 备用 CDN（CSP style/font/img 允许，index.html 有 preconnect）
+
+# ---- Google Fonts（子页面 quiz/resources/ebook/study/4xx 等引用；CSS 按 UA 协商，
+#      依 verify-third-party.js 的明确例外仅白名单、不强加 SRI；字体文件则从不经 src/href 直引）----
+fonts.googleapis.com
+fonts.gstatic.com
 
 # ---- 交互式模拟 iframe 内嵌（仅 frame-src，不加载静态资源，无需 SRI）----
 phet.colorado.edu

--- a/ebook.html
+++ b/ebook.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="css/header.css">
   <link rel="stylesheet" href="css/footer.css">
   <link rel="stylesheet" href="css/ebook.css">
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.115.0" integrity="sha384-EyR2P0dlmjnEGcm9xcjdAn0VedZpRHEwDLP9oSS6wYMvzHBHkUrvgonveazJ/sSx" crossorigin="anonymous"></script>
   <script src="js/supabase-client.js?v=20260608d"></script>
   <script src="js/supabase.js?v=20260608d"></script>
 </head>

--- a/index.html
+++ b/index.html
@@ -574,6 +574,18 @@
         </div>
       </section>
 
+      <!-- Issue #129（P3-36）：本地成就徽章集合（由 js/achievements.js 渲染，游客亦可查看） -->
+      <section class="ach-home-section" data-section="achievements" style="padding:48px 0 24px;">
+        <div class="container">
+          <div class="section-header">
+            <div class="section-label">ACHIEVEMENTS</div>
+            <h2 class="section-title">我的成就徽章</h2>
+            <p class="section-desc">完成练习、收藏题目、连续打卡即可解锁生物主题徽章</p>
+          </div>
+          <div id="homeAchievementsPanel" aria-live="polite"></div>
+        </div>
+      </section>
+
       <section class="social-impact-section" data-section="social-impact" style="padding:80px 0;background:linear-gradient(180deg,var(--surface-primary) 0%,rgba(90,125,92,0.04) 100%);">
         <div class="container">
           <div class="section-header" style="margin-bottom:40px;">
@@ -583,7 +595,7 @@
           </div>
           <div style="display:flex;flex-wrap:wrap;gap:28px;align-items:stretch;">
             <div style="flex:1;min-width:300px;border-radius:var(--radius-lg);overflow:hidden;border:1px solid var(--border-light);background:var(--surface-primary);box-shadow:var(--shadow-sm);position:relative;">
-              <img src="./images/biology-education.jpg" alt="桂林漓江山水" style="width:100%;height:220px;object-fit:cover;display:block;" loading="lazy">
+              <img src="./images/biology-education.jpg" alt="桂林漓江山水" style="width:100%;height:220px;object-fit:cover;display:block;" loading="lazy" decoding="async">
               <div style="position:absolute;bottom:0;right:0;background:rgba(0,0,0,0.55);color:#fff;font-size:0.65rem;padding:2px 6px;border-top-left-radius:6px;">Photo: Xiquinho Silva / CC BY 2.0 · Wikimedia Commons</div>
             </div>
               <div style="padding:24px;">

--- a/js/achievements.js
+++ b/js/achievements.js
@@ -420,6 +420,22 @@
     try {
       checkAndUnlock(gatherStats());
     } catch (e) { /* 自动触发失败静默，不阻塞页面 */ }
+    renderHomePanel();
+  }
+
+  /**
+   * #129（P3-36）：主页「我的成就徽章」面板。
+   * 主页存在 #homeAchievementsPanel 容器（index.html 固定区块）时，
+   * 将本地成就集合渲染进去——未登录/游客也能查看已收集徽章（不再只有一次性 toast）。
+   * 每次自动触发后重渲染，保证新解锁即时上板；容器不存在时零开销跳过。
+   */
+  function renderHomePanel() {
+    try {
+      if (!root || root.document === undefined) return;
+      var el = root.document.getElementById ? root.document.getElementById('homeAchievementsPanel') : null;
+      if (!el || typeof api.render !== 'function') return;
+      api.render(el);
+    } catch (e) { /* 面板渲染失败静默，不影响核心解锁流程 */ }
   }
 
   function init() {

--- a/js/app.js
+++ b/js/app.js
@@ -3323,36 +3323,43 @@ function _showPasswordSetup(onConfirm) {
   });
 
   // 字典攻击演示
-  var attackInterval = null;
+  var attackCancelId = null; // null 表示空闲，存 requestAnimationFrame id（#118：rAF 替代 setInterval）
   function stopAttack() {
-    if (attackInterval) clearInterval(attackInterval);
-    attackInterval = null;
+    if (attackCancelId !== null) cancelAnimationFrame(attackCancelId);
+    attackCancelId = null;
     attackStart.textContent = '开始攻击';
   }
   attackStart.addEventListener('click', function () {
-    if (attackInterval) { stopAttack(); return; }
+    if (attackCancelId !== null) { stopAttack(); return; }
     var pwd = input.value;
     if (!pwd) {
       attackStat.textContent = '请先输入密码';
       return;
     }
     attackStart.textContent = '停止';
-    attackFill.style.width = '0%';
+    attackFill.style.transform = 'scaleX(0)';
     attackFill.style.background = 'linear-gradient(90deg, #d63a2a, #e87a3a, #e8c43a, #a8d63a, #3a8c5c)';
     attackLog.innerHTML = '';
     var tried = 0;
+    var lastMs = Date.now();
     var speed = 50 + Math.floor(Math.random() * 30);
     var strength = _calcPasswordStrength(pwd).score;
     var maxTries = strength <= 1 ? 2000 : (strength <= 2 ? 20000 : (strength <= 3 ? 200000 : (strength <= 4 ? 5000000 : 99999999)));
     var likelyHit = strength <= 2;
 
-    attackInterval = setInterval(function () {
-      tried += speed;
+    function tick() {
+      if (attackCancelId === null) return; // 已停止
+      // 按真实时间步进，避免 rAF 在不同刷新率下速度不一致
+      var now = Date.now();
+      var elapsed = Math.max(1, now - lastMs);
+      lastMs = now;
+      tried += speed * (elapsed / 80);
+
       if (tried > maxTries) tried = maxTries;
-      var pct = Math.min(100, (tried / maxTries) * 100);
-      attackFill.style.width = pct + '%';
+      var pct = Math.min(1, tried / maxTries); // 0~1，配合 transform: scaleX
+      attackFill.style.transform = 'scaleX(' + pct + ')';
       var displayTried = tried >= 1000000 ? (tried / 1000000).toFixed(1) + 'M' :
-                        tried >= 1000 ? (tried / 1000).toFixed(1) + 'K' : String(tried);
+                        tried >= 1000 ? (tried / 1000).toFixed(1) + 'K' : String(Math.floor(tried));
       var displayMax = maxTries >= 1000000 ? (maxTries/1000000).toFixed(0) + 'M' : (maxTries/1000).toFixed(0) + 'K';
       attackStat.textContent = '尝试 ' + displayTried + ' / ' + displayMax;
 
@@ -3386,12 +3393,16 @@ function _showPasswordSetup(onConfirm) {
         attackLog.appendChild(safeLine);
         attackStat.textContent = '已停止';
         stopAttack();
+        return;
       }
-    }, 80);
+      attackCancelId = requestAnimationFrame(tick);
+    }
+    attackCancelId = requestAnimationFrame(tick);
   });
 
   cancelBtn.addEventListener('click', function () {
-    if (attackInterval) clearInterval(attackInterval);
+    if (attackCancelId !== null) cancelAnimationFrame(attackCancelId);
+    attackCancelId = null;
     modal.remove();
     if (typeof onConfirm === 'function') onConfirm(null);
   });
@@ -3405,7 +3416,8 @@ function _showPasswordSetup(onConfirm) {
       sarcastic.textContent = '"至少 6 位"';
       return;
     }
-    if (attackInterval) clearInterval(attackInterval);
+    if (attackCancelId !== null) cancelAnimationFrame(attackCancelId);
+    attackCancelId = null;
     modal.remove();
     if (typeof onConfirm === 'function') onConfirm(pwd);
   });

--- a/js/boot-lazy.js
+++ b/js/boot-lazy.js
@@ -26,11 +26,15 @@
   });
 
   // ---- Supabase 延迟加载 ----
+  // #104：动态注入同样固定精确版本并携带 SRI integrity（与各页面静态
+  // <script> 标签一致），杜绝"版本漂移 + 供应链被替换"风险。
+  var SUPABASE_JS_VERSION = '2.115.0';
+  var SUPABASE_JS_SRI = 'sha384-EyR2P0dlmjnEGcm9xcjdAn0VedZpRHEwDLP9oSS6wYMvzHBHkUrvgonveazJ/sSx';
   window.__supabaseLoaded = false;
   window.__loadSupabaseFallback = function (script) {
     if (window.__supabaseLoaded || typeof window.supabase !== 'undefined') return;
     var s = document.createElement('script');
-    s.src = 'https://unpkg.com/@supabase/supabase-js@2/dist/umd/supabase.min.js';
+    s.src = 'https://unpkg.com/@supabase/supabase-js@' + SUPABASE_JS_VERSION + '/dist/umd/supabase.min.js';
     s.defer = true;
     s.onerror = function () {
       console.warn('[BioQuest] Supabase SDK 镜像加载失败，将使用本地存储模式');
@@ -42,7 +46,9 @@
 
   function __loadSupabaseSDK() {
     var s = document.createElement('script');
-    s.src = 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2';
+    s.src = 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@' + SUPABASE_JS_VERSION;
+    s.integrity = SUPABASE_JS_SRI;
+    s.crossOrigin = 'anonymous';
     s.defer = true;
     s.onload = function () { window.__supabaseLoaded = true; };
     s.onerror = function () { window.__loadSupabaseFallback(this); };

--- a/js/user.js
+++ b/js/user.js
@@ -1991,12 +1991,22 @@ function renderRecordsPanel(container) {
   `;
 
   if (records.length === 0) {
-    html += `
-      <div class="user-empty-state">
-        <div class="user-empty-state-icon">暂无</div>
-        <p class="user-empty-state-text">暂无学习记录</p>
-      </div>
-    `;
+    // Issue #125（P3-22）：统一温暖空状态——生物主题 icon + 提示 + 行动按钮
+    if (window.BioQuest && typeof window.BioQuest.emptyStateHTML === 'function') {
+      html += window.BioQuest.emptyStateHTML({
+        icon: '🧪',
+        title: '暂无学习记录',
+        hint: '完成一次练习或考试后，记录会自动出现在这里',
+        action: { label: '去练习', onClick: function () { if (typeof navigateTo === 'function') navigateTo('/practice'); } }
+      });
+    } else {
+      html += `
+        <div class="user-empty-state">
+          <div class="user-empty-state-icon">🧪</div>
+          <p class="user-empty-state-text">暂无学习记录</p>
+        </div>
+      `;
+    }
   } else {
     html += '<div class="user-record-list">';
     records.forEach((rec) => {
@@ -2108,12 +2118,22 @@ function renderFavoritesPanel(container) {
   `;
 
   if (favIds.length === 0) {
-    html += `
-      <div class="user-empty-state">
-        <div class="user-empty-state-icon">[星]</div>
-        <p class="user-empty-state-text">暂无收藏题目</p>
-      </div>
-    `;
+    // Issue #125（P3-22）：统一温暖空状态——生物主题 icon + 提示 + 行动按钮
+    if (window.BioQuest && typeof window.BioQuest.emptyStateHTML === 'function') {
+      html += window.BioQuest.emptyStateHTML({
+        icon: '⭐',
+        title: '暂无收藏题目',
+        hint: '练习或浏览题库时点击「收藏」，题目就会出现在这里',
+        action: { label: '去练习', onClick: function () { if (typeof navigateTo === 'function') navigateTo('/practice'); } }
+      });
+    } else {
+      html += `
+        <div class="user-empty-state">
+          <div class="user-empty-state-icon">⭐</div>
+          <p class="user-empty-state-text">暂无收藏题目</p>
+        </div>
+      `;
+    }
   } else {
     html += '<div class="user-fav-list">';
 

--- a/quiz.html
+++ b/quiz.html
@@ -14,7 +14,7 @@
   <link rel="stylesheet" href="css/header.css">
   <link rel="stylesheet" href="css/footer.css">
   <link rel="stylesheet" href="css/quiz.css">
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.115.0" integrity="sha384-EyR2P0dlmjnEGcm9xcjdAn0VedZpRHEwDLP9oSS6wYMvzHBHkUrvgonveazJ/sSx" crossorigin="anonymous"></script>
   <script src="js/supabase-client.js?v=20260814c"></script>
   <script src="js/supabase.js?v=20260608d"></script>
 </head>

--- a/resources.html
+++ b/resources.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="css/header.css">
   <link rel="stylesheet" href="css/footer.css">
   <link rel="stylesheet" href="css/resources.css">
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.115.0" integrity="sha384-EyR2P0dlmjnEGcm9xcjdAn0VedZpRHEwDLP9oSS6wYMvzHBHkUrvgonveazJ/sSx" crossorigin="anonymous"></script>
   <script src="js/supabase-client.js?v=20260814c"></script>
   <script src="js/supabase.js?v=20260608d"></script>
 </head>

--- a/scripts/verify-third-party.js
+++ b/scripts/verify-third-party.js
@@ -6,8 +6,13 @@
  * 纯静态审计脚本，零依赖，不联网。即使 sandbox 配了 HTTPS_PROXY/HTTP_PROXY，
  * 本脚本也不发起任何网络请求 —— 全部输入来自磁盘文件。
  *
+ * 覆盖范围（比实现时更全）：
+ *   扫描仓库根目录下全部顶层 HTML 页面（index.html 及
+ *   quiz/resources/ebook/study/cards/wiki/biology-history/400/401/403/404/500/502/503 等），
+ *   而不仅限于 index.html —— 避免"子页面引用未白名单第三方资源"被漏检。
+ *
  * 校验内容：
- *   1) 域名白名单：/workspace/index.html 中所有外部 URL（src/href，http/https 开头，
+ *   1) 域名白名单：所有页面中所有外部 URL（src/href，http/https 开头，
  *      排除 data: 与 # 锚点）的域名，必须出现在 data/third-party-domains.txt 白名单，
  *      或内置豁免清单内，否则记 violation（未知域名）。
  *   2) 完整性校验（SRI integrity）：
@@ -15,14 +20,18 @@
  *        b. 外链 <script src="http...">
  *        c. 带 data-css-async 的 KaTeX 样式 preload（<link rel=preload as=style>）
  *      以上三类必须携带 integrity 属性，缺失则记 violation（缺完整性校验）。
+ *   例外（仅需白名单、不要求 SRI，均已书面说明理由）：
+ *       - fonts.googleapis.com 的 css2 样式表：谷歌按 User-Agent 协商返回不同
+ *         @font-face 字节（woff2 / woff 等），单一 SRI 哈希会使部分浏览器字体
+ *         被 CSP 拦截，故只白名单、不强加 SRI。
  *
- * 内置豁免清单（无需写入白名单文件即可豁免"未知域名"）：
+ * 内置豁免域名（无需写入白名单文件即可豁免"未知域名"）：
  *   - supabase.co       仅用于 CSP connect-src，不加载任何静态资源；
  *                       它只出现在 <meta http-equiv="Content-Security-Policy"> 的
  *                       content 区内，正则只匹配 src/href，天然跳过该元信息区域。
  *   - phet.colorado.edu frame 内嵌 iframe 模拟，不加载静态资源（同白名单）。
  *
- * 输出：JSON  { domains, externals:[{url, domain, integrity}], violations:[] }
+ * 输出：JSON  { pages, domains, externals:[{page,url,domain,integrity}], violations:[] }
  *   ok=true/false；存在 violation 时 exit 1。
  */
 
@@ -30,13 +39,17 @@ const fs = require('fs');
 const path = require('path');
 
 const ROOT = path.resolve(__dirname, '..');
-const HTML_PATH = path.join(ROOT, 'index.html');
 const WHITELIST_PATH = path.join(ROOT, 'data', 'third-party-domains.txt');
 
 // 内置豁免域名（只豁免"未知域名"判定；本身仍是允许的，不做 SRI 要求）
 const EXEMPT_DOMAINS = new Set([
   'supabase.co', // 仅 CSP connect-src，不加载静态资源
   'phet.colorado.edu', // frame 内嵌 iframe，不加载静态资源
+]);
+
+// 例外域名：白名单必达，但 SRI 可豁免（理由见文件头注释）
+const NO_SRI_ENFORCE = new Set([
+  'fonts.googleapis.com', // UA 协商的字体 CSS，单一 SRI 会误伤部分浏览器
 ]);
 
 const EXEMPT_NOTE = {
@@ -96,59 +109,77 @@ function hostnameOf(u) {
   }
 }
 
+function listHtmlPages() {
+  return fs
+    .readdirSync(ROOT)
+    .filter((f) => {
+      if (!f.endsWith('.html')) return false;
+      try {
+        return fs.statSync(path.join(ROOT, f)).isFile();
+      } catch (e) {
+        return false;
+      }
+    })
+    .sort();
+}
+
 function run() {
   const whitelist = readWhitelist();
-  const html = fs.readFileSync(HTML_PATH, 'utf8');
-
-  const tokens = collectTagTokens(html);
+  const pages = listHtmlPages();
   const violations = [];
   const externals = [];
   const domains = [];
 
-  for (const t of tokens) {
-    if (!isHttpUrl(t.url)) continue; // 本地/相对路径、data:、#锚点全部跳过
+  for (const page of pages) {
+    const html = fs.readFileSync(path.join(ROOT, page), 'utf8');
+    const tokens = collectTagTokens(html);
 
-    const domain = hostnameOf(t.url);
-    const recognized = whitelist.has(domain) || EXEMPT_DOMAINS.has(domain);
+    for (const t of tokens) {
+      if (!isHttpUrl(t.url)) continue; // 本地/相对路径、data:、#锚点全部跳过
 
-    // 判定该元素是否属于"必须带 SRI integrity"的静态资源
-    const isStyle = t.kind === 'link' && t.rel && /\bstylesheet\b/i.test(t.rel);
-    const isKatexPreload =
-      t.kind === 'link' &&
-      t.rel === 'preload' &&
-      t.as === 'style' &&
-      t.cssAsync &&
-      /katex/i.test(t.url);
-    const isExternalScript = t.kind === 'script';
+      const domain = hostnameOf(t.url);
+      const recognized = whitelist.has(domain) || EXEMPT_DOMAINS.has(domain);
 
-    const requiresSRI = isStyle || isKatexPreload || isExternalScript;
-    const hasIntegrity = Boolean(t.integrity);
+      // 判定该元素是否属于"必须带 SRI integrity"的静态资源
+      const isStyle = t.kind === 'link' && t.rel && /\bstylesheet\b/i.test(t.rel);
+      const isKatexPreload =
+        t.kind === 'link' &&
+        t.rel === 'preload' &&
+        t.as === 'style' &&
+        t.cssAsync &&
+        /katex/i.test(t.url);
+      const isExternalScript = t.kind === 'script';
 
-    // externals 按 url 去重，integrity 反映是否带 integrity 属性
-    if (!externals.some((e) => e.url === t.url)) {
-      externals.push({ url: t.url, domain, integrity: hasIntegrity });
-    }
-    if (!domains.includes(domain)) domains.push(domain);
+      const requiresSRI = (isStyle || isKatexPreload || isExternalScript) &&
+        !(isStyle && NO_SRI_ENFORCE.has(domain)); // 例外：UA 协商 CSS 只白名单不强加 SRI
+      const hasIntegrity = Boolean(t.integrity);
 
-    if (!recognized) {
-      violations.push(`未知域名（不在白名单/豁免清单）：${domain} → ${t.url}`);
-    }
+      // externals 按 page+url 去重，integrity 反映是否带 integrity 属性
+      if (!externals.some((e) => e.page === page && e.url === t.url)) {
+        externals.push({ page, url: t.url, domain, integrity: hasIntegrity });
+      }
+      if (!domains.includes(domain)) domains.push(domain);
 
-    if (requiresSRI && !hasIntegrity) {
-      const kindDesc = isExternalScript
-        ? '外链脚本 <script src>'
-        : isKatexPreload
-          ? 'KaTeX 样式 preload (data-css-async)'
-          : '外链样式表 <link rel="stylesheet">';
-      violations.push(`缺少完整性校验 (integrity 缺失)：${kindDesc} → ${t.url}`);
+      if (!recognized) {
+        violations.push(`未知域名（不在白名单/豁免清单）：${domain} → ${page}: ${t.url}`);
+      }
+
+      if (requiresSRI && !hasIntegrity) {
+        const kindDesc = isExternalScript
+          ? '外链脚本 <script src>'
+          : isKatexPreload
+            ? 'KaTeX 样式 preload (data-css-async)'
+            : '外链样式表 <link rel="stylesheet">';
+        violations.push(`缺少完整性校验 (integrity 缺失)：${kindDesc} → ${page}: ${t.url}`);
+      }
     }
   }
 
   const ok = violations.length === 0;
   console.log(
-    JSON.stringify({ domains: domains.sort(), externals, violations }, null, 2)
+    JSON.stringify({ pages, domains: domains.sort(), externals, violations }, null, 2)
   );
-  console.log(`\nok=${ok}  violations=${violations.length}  whitelist=${whitelist.size}  exempt=${[...EXEMPT_DOMAINS].map((d) => `${d}(${EXEMPT_NOTE[d]})`).join(' | ')}`);
+  console.log(`\nok=${ok}  pages=${pages.length}  domains=${domains.length}  externals=${externals.length}  violations=${violations.length}  whitelist=${whitelist.size}  exempt=[${[...EXEMPT_DOMAINS].map((d) => `${d}(${EXEMPT_NOTE[d]})`).join(' | ')}]  noSriEnforce=[${[...NO_SRI_ENFORCE].join(' | ')}]`);
   process.exitCode = ok ? 0 : 1;
 }
 

--- a/study.html
+++ b/study.html
@@ -14,7 +14,7 @@
   <link rel="stylesheet" href="css/header.css">
   <link rel="stylesheet" href="css/footer.css">
   <link rel="stylesheet" href="css/study.css">
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.115.0" integrity="sha384-EyR2P0dlmjnEGcm9xcjdAn0VedZpRHEwDLP9oSS6wYMvzHBHkUrvgonveazJ/sSx" crossorigin="anonymous"></script>
   <script src="js/supabase-client.js?v=20260608d"></script>
   <script src="js/supabase.js?v=20260608d"></script>
 </head>

--- a/sw.js
+++ b/sw.js
@@ -9,7 +9,7 @@
 // P1-4 修复：CACHE_VERSION 由 scripts/bump-sw.js 基于 git 跟踪的 js/css/data
 // 内容哈希自动生成——修改任何 JS/CSS/data 后运行 `npm run bump:sw` 即可，
 // 不再依赖人肉维护版本号。版本号变化会触发 activate 阶段清理旧缓存并重新预热。
-var CACHE_VERSION = 'bioquest-ba6cb12aeef8'; // ← bump-sw.js 会自动改写此行
+var CACHE_VERSION = 'bioquest-0af18dc6c296'; // ← bump-sw.js 会自动改写此行
 var CACHE_NAME = 'bioquest-cache-' + CACHE_VERSION;
 
 /* ========================================================================


### PR DESCRIPTION
## 概述

修复 / 落实仓库剩余 7 个 P3 issue

| Issue | 修复内容 |
| --- | --- |
| [#129](https://github.com/astrnox/BioQuest/issues/129) P3-36 成就/激励系统 | 主页新增「我的成就徽章」面板（`#homeAchievementsPanel`），由 `js/achievements.js` 渲染本地成就集合，游客亦可查看已收集徽章；每次解锁/记录事件后自动重渲染 |
| [#127](https://github.com/astrnox/BioQuest/issues/127) P3-34 暗色模式过渡 | 主题过渡规则扩展至 `opacity/fill/stroke`，覆盖 SVG 图标等更多表面；`prefers-reduced-motion` 仍被尊重 |
| [#125](https://github.com/astrnox/BioQuest/issues/125) P3-22 空状态 | 「学习记录」「收藏夹」数据为空时不再生硬 |
| [#118](https://github.com/astrnox/BioQuest/issues/118) P3-3 动画性能 | 练习加载条 `@keyframes` 由 `width` 改为 `transform: scaleX`（合成层）；密码强度演示进度改用 `requestAnimationFrame` + `scaleX`，消除逐帧重排 |
| [#116](https://github.com/astrnox/BioQuest/issues/116) P3-14 图片懒加载 | 补充 `decoding="async"`；非首屏图片懒加载引擎（`lazy-images.js`）已在页面加载 |
| [#113](https://github.com/astrnox/BioQuest/issues/113) P3-1 提交规范 | CI 门禁（`scripts/check-commit-msg.js`）与 CONTRIBUTING 约定确认生效；本 PR 提交即符合 Conventional Commits 且引用 issue |
| [#104](https://github.com/astrnox/BioQuest/issues/104) P3-2 三方资源 | `verify-third-party.js` 覆盖范围从 index.html 扩展到全部 15 个顶层 HTML 页；supabase-js 固定精确版本 `2.115.0` 并补 SRI（静态标签 + 动态注入 `boot-lazy.js`）；Google Fonts UA 协商例外已书面化 |

## 验证（已全部通过）

- `npm run lint:js`（node --check 全部 JS）✔
- `node scripts/verify-vendor-integrity.js`（35 个 vendor 哈希一致）✔
- `node scripts/verify-third-party.js`（15 页 0 violation）✔
- `node scripts/verify-manifest-anchor.js` / `verify-bio-shards.js` / `audit-rls.js` ✔
- `npm run test:unit`（19 套件 / 143 用例 + 覆盖率门禁）✔
- `npm run test:smoke`（29/29）✔
- Playwright E2E `tests/e2e-smoke.js`（9 路由 + 2 重定向，0 pageerror / 0 console error）✔
- 真实浏览器逐项验证 11/11：成就引擎加载/首页面板渲染/事件解锁上板、主题过渡类添加与移除、空状态组件、supabase SRI 属性、图片 lazy/async → 见下截图

## 截图（浏览器实测）

主页「我的成就徽章」面板：

![主页成就面板](/tmp/ach-panel.png)

Closes #129, Closes #127, Closes #125, Closes #118, Closes #116, Closes #113, Closes #104