### PR TITLE
fix: 修复练习页本地题库不显示题目

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -406,8 +406,15 @@ function _loadManifestFresh(timeoutMs) {
 
 function _loadBioIdMap(signal) {
   if (_bioidMap) return Promise.resolve(_bioidMap);
-  // Issue #15：映射表（大文件）走 CDN 优先 + SHA 校验 + 同源回退，失败静默降级空表
+  // 数据体系重构（#150）后 bioid-map.json 已从 manifest.files 移除。
+  // 未注册时不再发起请求，直接使用空映射表——既避免每次题库加载产生 404 噪声，
+  // 也避免 E2E 的"本机静态资源无 4xx/5xx"检查拦截。
   var expected = (_shardManifest && _shardManifest.files && _shardManifest.files['bioid-map.json']) || null;
+  if (!expected) {
+    _bioidMap = {};
+    window.bioIdMap = _bioidMap;
+    return Promise.resolve(_bioidMap);
+  }
   return _fetchShardText('data/bioid-map.json', expected, signal).then(function (res) {
     return JSON.parse(res.text);
   }).then(function (map) {

--- a/js/practice.js
+++ b/js/practice.js
@@ -1568,13 +1568,54 @@ async function handlePullQuestions() {
   var targets = PracticeState.selectedTargets || [];
   var concept = PracticeState.conceptFilter || null;
 
+  var qSource = (typeof loadSetting === 'function') ? loadSetting('question_source', 'cloud') : 'cloud';
+  var items = null;
+
   btn.disabled = true;
   btn.textContent = '拉取中...';
-  _setPullStatus('正在从 Supabase 拉取 ' + countVal + ' 道题…', 'info');
+  _setPullStatus(qSource === 'local' ? '正在从本地题库抽取 ' + countVal + ' 道题…' : '正在从 Supabase 拉取 ' + countVal + ' 道题…', 'info');
 
   try {
-    // 主动确保 loader.js 已加载（解决 loader.js 未在 index.html 预加载的问题）
-    if (typeof window.fetchQuestionsBatch !== 'function') {
+    // 本地题库模式：直接从 data/bank 分片按筛选条件抽题，不请求 Supabase
+    if (qSource === 'local') {
+      if (!PracticeState.allQuestions || PracticeState.allQuestions.length === 0) {
+        if (typeof window.loadQuestions !== 'function') {
+          throw new Error('本地题库加载器未就绪，请刷新页面重试');
+        }
+        var localModNums = [];
+        for (var im = 0; im < modules.length; im++) {
+          var mn = parseInt(String(modules[im]).replace('module_', ''), 10);
+          if (mn >= 1 && mn <= 4) localModNums.push(mn);
+        }
+        if (localModNums.length === 0) localModNums = [1, 2, 3, 4];
+        var localItems = await window.loadQuestions(localModNums, { mode: 'preferLocal' });
+        PracticeState.allQuestions = (localItems || []).filter(function (q) {
+          return Array.isArray(q.subQuestions) && q.subQuestions.length >= 4;
+        });
+      }
+      var lDiffAlias = { easy: ['easy', 'basic'], medium: ['medium', 'league'], hard: ['hard', 'national'] };
+      var lAccDiffs = [];
+      (difficulties || []).forEach(function (d) {
+        (lDiffAlias[d] || [d]).forEach(function (v) { if (lAccDiffs.indexOf(v) < 0) lAccDiffs.push(v); });
+      });
+      var lAccTargets = (targets || []).filter(function (t) { return t !== 'both'; });
+      items = (PracticeState.allQuestions || []).filter(function (q) {
+        if (!q || !q.subQuestions || q.subQuestions.length < 4) return false;
+        if (lAccDiffs.length > 0 && lAccDiffs.indexOf(q.difficulty) < 0) return false;
+        if (q.target && lAccTargets.length > 0 && lAccTargets.indexOf(q.target) < 0) return false;
+        if (concept) {
+          var inTags = q.tags && q.tags.join(' ').indexOf(concept) >= 0;
+          var inText = String(q.concept || '') === concept ||
+            String(q.question || '').indexOf(concept) >= 0 ||
+            String(q.explanation || '').indexOf(concept) >= 0;
+          if (!inTags && !inText) return false;
+        }
+        return true;
+      }).slice().sort(function () { return Math.random() - 0.5; }).slice(0, countVal);
+    } else {
+      // 云题库模式：原 Supabase 拉取流程
+      // 主动确保 loader.js 已加载（解决 loader.js 未在 index.html 预加载的问题）
+      if (typeof window.fetchQuestionsBatch !== 'function') {
       _setPullStatus('正在初始化题库加载器…', 'info');
       var loaderOk = false;
       // 兼容路径 A：loader.js 已在页面中且暴露了 ensureQuestionLoaderReady
@@ -1629,13 +1670,14 @@ async function handlePullQuestions() {
       }
     }
 
-    var items = await window.fetchQuestionsBatch({
+    items = await window.fetchQuestionsBatch({
       modules: modules,
       difficulties: difficulties,
       targets: targets,
       concept: concept,
       count: countVal
     });
+    }
 
     if (!items || items.length === 0) {
       throw new Error('没有符合条件的题目，请放宽筛选条件');
@@ -2179,6 +2221,22 @@ function showSummary() {
 function showFilterPanel() {
   applyFilters();
   renderFilterPanel();
+
+  // 修复：进入练习页时自动加载题库（本地分片 + 逻辑推理），
+  // 否则所有入口（含"本地题库"）初次进入时 allQuestions 为空，
+  // 必须等用户点击"拉取题目"，而该按钮在本地模式下原先仍只请求 Supabase。
+  if (!PracticeState.allQuestions || PracticeState.allQuestions.length === 0) {
+    Promise.all([loadPracticeQuestions(), loadLogicQuestions()]).then(function () {
+      if (!document.getElementById('practice-root')) return;
+      applyFilters();
+      renderFilterPanel(); // 重建面板以显示"共 X 道可用题目"
+    }).catch(function () {});
+  } else if (!PracticeState.logicLoaded) {
+    loadLogicQuestions().then(function () {
+      applyFilters();
+      updateAvailableCount();
+    }).catch(function () {});
+  }
 }
 
 function renderPracticePage(target) {

--- a/sw.js
+++ b/sw.js
@@ -9,7 +9,7 @@
 // P1-4 修复：CACHE_VERSION 由 scripts/bump-sw.js 基于 git 跟踪的 js/css/data
 // 内容哈希自动生成——修改任何 JS/CSS/data 后运行 `npm run bump:sw` 即可，
 // 不再依赖人肉维护版本号。版本号变化会触发 activate 阶段清理旧缓存并重新预热。
-var CACHE_VERSION = 'bioquest-0af18dc6c296'; // ← bump-sw.js 会自动改写此行
+var CACHE_VERSION = 'bioquest-e8f0ecccdfd3'; // ← bump-sw.js 会自动改写此行
 var CACHE_NAME = 'bioquest-cache-' + CACHE_VERSION;
 
 /* ========================================================================


### PR DESCRIPTION
## 问题现象

练习页（#/practice）选择「本地题库」后仍然看不到任何题目。

## 根因（3 处叠加）

1. **进入页面从不加载题库**：`renderPracticePage` 只调 `showFilterPanel()`（不触发 `loadPracticeQuestions`），`allQuestions` 恒为空；点「开始练习」永远提示“题库为空，请先点击下方「拉取题目」加载题目”。
2. **「拉取题目」无视本地模式**：`fetchQuestionsBatch` 为纯 Supabase REST 查询。本地题库模式下仍请求 Supabase——而 11 道新题只存在于本地 `data/bank` 分片，Supabase 中并没有 → 返回空 → “没有符合条件的题目”。
3. **逻辑推理题从未加载**：`loadLogicQuestions()` 全仓库只有定义、没有任何调用。

## 改动

- `js/practice.js`：
  - `showFilterPanel()` 检测题库为空时自动 `loadPracticeQuestions()` + `loadLogicQuestions()`，完成后重建面板显示“共 X 道可用题目”，可直接点击「开始练习」；
  - 「拉取题目」在 `question_source === 'local'` 时改为从 `data/bank` 分片按模块/难度/目标/概念过滤抽题，不再请求 Supabase；云模式走原流程不变。
- `sw.js`：重跑 `npm run bump:sw` 刷新 CACHE_VERSION，确保客户端拿到新逻辑。

## 验证

- jsdom 复现进入练习页（本地题库）：显示“共 51 道可用题目”（11 本地题 + 40 逻辑题）✅
- `node --check` 语法 ✅
- 143 个单元测试 + manifest 锚点校验全部通过 ✅